### PR TITLE
Refactor `standardInitialization` to support custom LionWeb versions

### DIFF
--- a/core/src/main/java/io/lionweb/serialization/SerializationProvider.java
+++ b/core/src/main/java/io/lionweb/serialization/SerializationProvider.java
@@ -69,7 +69,7 @@ public class SerializationProvider {
    * getStandardJsonSerialization instead.
    *
    * <p>This method allows to consider core languages from a different LionWeb Version than the one
-   * used for serialization. This may be useful in the contest of upgrading or downgrading the
+   * used for serialization. This may be useful in the context of upgrading or downgrading the
    * LionWeb Version.
    */
   public static void standardInitialization(


### PR DESCRIPTION
Overload `standardInitialization` to allow specifying a custom `LionWebVersion` for core languages.

Fix #289 