### PR TITLE
fix: add null check for registerPartitionObserver parameter

### DIFF
--- a/core/src/main/java/io/lionweb/model/impl/AbstractNode.java
+++ b/core/src/main/java/io/lionweb/model/impl/AbstractNode.java
@@ -2,6 +2,7 @@ package io.lionweb.model.impl;
 
 import io.lionweb.language.Concept;
 import io.lionweb.model.*;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -33,7 +34,8 @@ public abstract class AbstractNode extends AbstractClassifierInstance<Concept> i
   }
 
   @Override
-  public boolean registerPartitionObserver(@Nullable PartitionObserver observer) {
+  public boolean registerPartitionObserver(@Nonnull PartitionObserver observer) {
+    Objects.requireNonNull(observer, "observer should not be null");
     if (!this.isRoot()) {
       throw new UnsupportedOperationException(
           "Cannot register a partition observer on a node which is not root");

--- a/core/src/main/java/io/lionweb/model/impl/DynamicNode.java
+++ b/core/src/main/java/io/lionweb/model/impl/DynamicNode.java
@@ -45,7 +45,8 @@ public class DynamicNode extends DynamicClassifierInstance<Concept>
   }
 
   @Override
-  public boolean registerPartitionObserver(@Nullable PartitionObserver observer) {
+  public boolean registerPartitionObserver(@Nonnull PartitionObserver observer) {
+    Objects.requireNonNull(observer, "observer should not be null");
     if (!this.isRoot()) {
       throw new UnsupportedOperationException(
           "Cannot register a partition observer on a node which is not root");

--- a/core/src/main/java/io/lionweb/model/impl/ProxyNode.java
+++ b/core/src/main/java/io/lionweb/model/impl/ProxyNode.java
@@ -156,7 +156,8 @@ public class ProxyNode extends AbstractNode {
   }
 
   @Override
-  public boolean registerPartitionObserver(@Nullable PartitionObserver observer) {
+  public boolean registerPartitionObserver(@Nonnull PartitionObserver observer) {
+    Objects.requireNonNull(observer, "observer should not be null");
     throw cannotDoBecauseProxy();
   }
 


### PR DESCRIPTION
## Summary

\`registerPartitionObserver\` previously accepted \`@Nullable PartitionObserver\` but would throw a \`NullPointerException\` deep in the call chain if \`null\` was passed. This strengthens the contract to \`@Nonnull\` with an explicit \`Objects.requireNonNull\` guard in \`AbstractNode\`, \`DynamicNode\`, and \`ProxyNode\`.

## Test plan
- [ ] Run \`./gradlew :core:test\` — existing tests should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)