### PR TITLE
fix: update integration test paths after lionweb-integration-testing restructure

### DIFF
--- a/core/src/integrationTest/java/io/lionweb/testset/ALanguageTestset.java
+++ b/core/src/integrationTest/java/io/lionweb/testset/ALanguageTestset.java
@@ -18,9 +18,7 @@ public abstract class ALanguageTestset extends ATestset {
   public void loadLanguage() {
     this.language =
         loadLanguage(
-            findIntegrationTests()
-                .resolve("withLanguage")
-                .resolve("myLang.language.json"));
+            findIntegrationTests().resolve("withLanguage").resolve("myLang.language.json"));
   }
 
   protected JsonSerialization getSerialization() {

--- a/core/src/integrationTest/java/io/lionweb/testset/ALanguageTestset.java
+++ b/core/src/integrationTest/java/io/lionweb/testset/ALanguageTestset.java
@@ -19,7 +19,6 @@ public abstract class ALanguageTestset extends ATestset {
     this.language =
         loadLanguage(
             findIntegrationTests()
-                // .resolve("testset")
                 .resolve("withLanguage")
                 .resolve("myLang.language.json"));
   }

--- a/core/src/integrationTest/java/io/lionweb/testset/Invalid.java
+++ b/core/src/integrationTest/java/io/lionweb/testset/Invalid.java
@@ -20,7 +20,7 @@ public class Invalid {
 
   public static Stream<Path> inputFiles() {
     Path integrationTests = ATestset.findIntegrationTests();
-    Path basePath = integrationTests.resolve("invalid");
+    Path basePath = integrationTests.resolve("withoutLanguage").resolve("invalid");
     return Arrays.stream(
             ATestset.collectJsonFiles(
                 basePath, ignored.stream().map(s -> Paths.get(s)).collect(Collectors.toSet())))

--- a/core/src/integrationTest/java/io/lionweb/testset/Valid.java
+++ b/core/src/integrationTest/java/io/lionweb/testset/Valid.java
@@ -16,7 +16,7 @@ public class Valid {
 
   public static Stream<Path> inputFiles() {
     Path integrationTests = ATestset.findIntegrationTests();
-    Path basePath = integrationTests.resolve("valid");
+    Path basePath = integrationTests.resolve("withoutLanguage").resolve("valid");
     return Arrays.stream(ATestset.collectJsonFiles(basePath)).map(p -> (Path) p);
   }
 }


### PR DESCRIPTION
## Summary

- The \`lionweb-integration-testing\` repository reorganised its \`testset/\` directory: \`testset/valid\` and \`testset/invalid\` became \`testset/withoutLanguage/valid\` and \`testset/withoutLanguage/invalid\`
- This caused all \`Valid\` and \`Invalid\` parameterised integration tests to fail on CI (fresh clone) while passing locally (stale cached clone)
- Updated the two path \`resolve()\` calls in \`Valid.java\` and \`Invalid.java\` accordingly

## Test plan
- [x] Run \`./gradlew integrationTest\` — 456 tests should pass
- [x] Delete \`core/build/integrationTestResources\` first to force a fresh clone and confirm the new paths are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)