### PR TITLE
fix: use explicit UTF-8 encoding in file I/O

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+### Version 1.3.10
+
+* Upgrade Gradle wrapper to 9.4.1
+* Fix encoding issues in file I/O by using explicit UTF-8 encoding instead of platform default charset
+* Add support for custom charsets in JSON serialization/deserialization methods
+* Fix Gradle plugin task validation errors for Gradle 9 compatibility (`@CacheableTask` on generation tasks)
+* Fix code generation task to run on Java 11+ (MWE2 launcher requirement)
+* Upgrade Kotlin to 2.3.20
+* Upgrade org.eclipse.emf.ecore.xmi to 2.40.0
+* Upgrade protobuf-java to 4.34.1
+* Upgrade com.github.gmazzo.buildconfig to 6.0.9
+
+### Version 1.3.9
+
+* Fix null check for `registerPartitionObserver` parameter
+* Fix integration test paths after lionweb-integration-testing restructure
+* Performance optimization for `LanguageVersion.of` with fast path cache lookup
+* Simplify `Containment` and `Property` construction by including ID in constructor
+* Remove SpotBugs integration
+
+### Version 1.3.8
+
+* Further serialization and deserialization performance improvements
+* Add classifier indexing to `RepositoryData` for efficient node retrieval
+* Optimize `hashCode` caching in `ClassifierKey`
+* Add O(1) `placeAt` method for efficient node sorting during deserialization
+
 ### Version 1.3.7
 
 * Introducing benchmarks

--- a/core/src/main/java/io/lionweb/serialization/JsonSerialization.java
+++ b/core/src/main/java/io/lionweb/serialization/JsonSerialization.java
@@ -14,6 +14,7 @@ import io.lionweb.serialization.data.*;
 import io.lionweb.utils.NetworkUtils;
 import java.io.*;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -35,16 +36,20 @@ import javax.annotation.Nonnull;
  */
 public class JsonSerialization extends AbstractSerialization {
 
-  public static void saveLanguageToFile(Language language, File file) throws IOException {
+  public static void saveLanguageToFile(Language language, File file, Charset charset)
+      throws IOException {
     String content =
         getStandardJsonSerialization(language.getLionWebVersion())
             .serializeTreesToJsonString(language);
     file.getParentFile().mkdirs();
     BufferedWriter writer =
-        new BufferedWriter(
-            new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8));
+        new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file), charset));
     writer.write(content);
     writer.close();
+  }
+
+  public static void saveLanguageToFile(Language language, File file) throws IOException {
+    saveLanguageToFile(language, file, StandardCharsets.UTF_8);
   }
 
   /**
@@ -214,8 +219,11 @@ public class JsonSerialization extends AbstractSerialization {
     return deserializeToNodes(JsonParser.parseString(json));
   }
 
+  public List<Node> deserializeToNodes(InputStream inputStream, Charset charset) {
+    return deserializeToNodes(JsonParser.parseReader(new InputStreamReader(inputStream, charset)));
+  }
+
   public List<Node> deserializeToNodes(InputStream inputStream) {
-    return deserializeToNodes(
-        JsonParser.parseReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8)));
+    return deserializeToNodes(inputStream, StandardCharsets.UTF_8);
   }
 }

--- a/core/src/main/java/io/lionweb/serialization/JsonSerialization.java
+++ b/core/src/main/java/io/lionweb/serialization/JsonSerialization.java
@@ -40,7 +40,9 @@ public class JsonSerialization extends AbstractSerialization {
         getStandardJsonSerialization(language.getLionWebVersion())
             .serializeTreesToJsonString(language);
     file.getParentFile().mkdirs();
-    BufferedWriter writer = new BufferedWriter(new FileWriter(file));
+    BufferedWriter writer =
+        new BufferedWriter(
+            new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8));
     writer.write(content);
     writer.close();
   }
@@ -213,6 +215,7 @@ public class JsonSerialization extends AbstractSerialization {
   }
 
   public List<Node> deserializeToNodes(InputStream inputStream) {
-    return deserializeToNodes(JsonParser.parseReader(new InputStreamReader(inputStream)));
+    return deserializeToNodes(
+        JsonParser.parseReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8)));
   }
 }

--- a/core/src/main/java/io/lionweb/serialization/LowLevelJsonSerialization.java
+++ b/core/src/main/java/io/lionweb/serialization/LowLevelJsonSerialization.java
@@ -1,5 +1,6 @@
 package io.lionweb.serialization;
 
+import com.google.common.base.Charsets;
 import com.google.gson.*;
 import io.lionweb.LionWebVersion;
 import io.lionweb.serialization.data.*;
@@ -7,7 +8,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
@@ -70,10 +71,14 @@ public class LowLevelJsonSerialization {
    * <p>This method follows a "best-effort" approach, try to limit exception thrown and return data
    * whenever is possible, in the measure that it is possible.
    */
-  public SerializationChunk deserializeSerializationBlock(File file) throws FileNotFoundException {
+  public SerializationChunk deserializeSerializationBlock(File file, Charset charset)
+      throws FileNotFoundException {
     return deserializeSerializationBlock(
-        JsonParser.parseReader(
-            new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8)));
+        JsonParser.parseReader(new InputStreamReader(new FileInputStream(file), charset)));
+  }
+
+  public SerializationChunk deserializeSerializationBlock(File file) throws FileNotFoundException {
+    return deserializeSerializationBlock(file, Charsets.UTF_8);
   }
 
   public JsonElement serializeToJsonElement(SerializationChunk serializationChunk) {

--- a/core/src/main/java/io/lionweb/serialization/LowLevelJsonSerialization.java
+++ b/core/src/main/java/io/lionweb/serialization/LowLevelJsonSerialization.java
@@ -4,8 +4,10 @@ import com.google.gson.*;
 import io.lionweb.LionWebVersion;
 import io.lionweb.serialization.data.*;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
@@ -69,7 +71,9 @@ public class LowLevelJsonSerialization {
    * whenever is possible, in the measure that it is possible.
    */
   public SerializationChunk deserializeSerializationBlock(File file) throws FileNotFoundException {
-    return deserializeSerializationBlock(JsonParser.parseReader(new FileReader(file)));
+    return deserializeSerializationBlock(
+        JsonParser.parseReader(
+            new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8)));
   }
 
   public JsonElement serializeToJsonElement(SerializationChunk serializationChunk) {

--- a/core/src/main/java/io/lionweb/utils/NetworkUtils.java
+++ b/core/src/main/java/io/lionweb/utils/NetworkUtils.java
@@ -6,6 +6,7 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 public class NetworkUtils {
@@ -26,7 +27,7 @@ public class NetworkUtils {
         result.write(buffer, 0, length);
       }
 
-      return result.toString();
+      return result.toString(StandardCharsets.UTF_8.name());
     }
   }
 

--- a/core/src/main/java/io/lionweb/utils/NetworkUtils.java
+++ b/core/src/main/java/io/lionweb/utils/NetworkUtils.java
@@ -6,6 +6,7 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
@@ -15,11 +16,16 @@ public class NetworkUtils {
     // Prevent instantiation
   }
 
-  public static String getStringFromUrl(URL url) throws IOException {
-    return inputStreamToString(urlToInputStream(url, null));
+  public static String getStringFromUrl(URL url, Charset charset) throws IOException {
+    return inputStreamToString(urlToInputStream(url, null), charset);
   }
 
-  private static String inputStreamToString(InputStream inputStream) throws IOException {
+  public static String getStringFromUrl(URL url) throws IOException {
+    return getStringFromUrl(url, StandardCharsets.UTF_8);
+  }
+
+  private static String inputStreamToString(InputStream inputStream, Charset charset)
+      throws IOException {
     try (ByteArrayOutputStream result = new ByteArrayOutputStream()) {
       byte[] buffer = new byte[1024];
       int length;
@@ -27,7 +33,7 @@ public class NetworkUtils {
         result.write(buffer, 0, length);
       }
 
-      return result.toString(StandardCharsets.UTF_8.name());
+      return result.toString(charset.name());
     }
   }
 

--- a/core/src/test/java/io/lionweb/serialization/LowLevelJsonSerializationTest.java
+++ b/core/src/test/java/io/lionweb/serialization/LowLevelJsonSerializationTest.java
@@ -17,8 +17,12 @@ import io.lionweb.model.Node;
 import io.lionweb.model.impl.DynamicAnnotationInstance;
 import io.lionweb.model.impl.DynamicNode;
 import io.lionweb.serialization.data.*;
+import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -112,6 +116,22 @@ public class LowLevelJsonSerializationTest extends SerializationTest {
     List<Node> deserializedNodes = hjs.deserializeToNodes(je);
     assertEquals(1, deserializedNodes.size());
     assertInstancesAreEquals(n1, deserializedNodes.get(0));
+  }
+
+  @Test
+  public void deserializeLionCoreFromFile() throws IOException {
+    File tempFile = File.createTempFile("lioncore", ".json");
+    tempFile.deleteOnExit();
+    try (InputStream in = this.getClass().getResourceAsStream("/serialization/lioncore.json");
+        OutputStream out = Files.newOutputStream(tempFile.toPath())) {
+      byte[] buf = new byte[8192];
+      int n;
+      while ((n = in.read(buf)) != -1) out.write(buf, 0, n);
+    }
+    LowLevelJsonSerialization jsonSerialization = new LowLevelJsonSerialization();
+    SerializationChunk serializationChunk =
+        jsonSerialization.deserializeSerializationBlock(tempFile);
+    assertFalse(serializationChunk.getClassifierInstances().isEmpty());
   }
 
   @Test


### PR DESCRIPTION
## Summary

Replaces \`FileReader\` / \`FileWriter\` with \`InputStreamReader\` / \`OutputStreamWriter\` using \`StandardCharsets.UTF_8\` in:
- \`JsonSerialization\` (saveLanguageToFile, deserializeToNodes(File))
- \`LowLevelJsonSerialization\` (deserializeSerializationBlock(File))
- \`NetworkUtils\` (toString)

On platforms where the JVM default charset differs from UTF-8, the old code could silently corrupt non-ASCII content. Also adds a test for the \`deserializeSerializationBlock(File)\` overload which was previously uncovered.

## Test plan
- [ ] Run \`./gradlew :core:test\` — all tests including the new file-based deserialization test should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)