### PR TITLE
Direct protobuffer serialization

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -304,6 +304,15 @@ tasks.register<Test>("performanceTest") {
     }
 }
 
+tasks.register<JavaExec>("jmhBenchmark") {
+    group = "Verification"
+    description = "Runs JMH benchmarks in src/performanceTest/java"
+    dependsOn("performanceTestClasses")
+    classpath = performanceTestSourceSet.runtimeClasspath
+    mainClass.set("org.openjdk.jmh.Main")
+    args = listOf("ProtoBufBytesBenchmark", "-prof", "gc")
+}
+
 idea {
     module {
         testSources.from(performanceTestSourceSet.java.srcDirs)

--- a/core/src/main/java/io/lionweb/serialization/DirectProtoBufDeserializer.java
+++ b/core/src/main/java/io/lionweb/serialization/DirectProtoBufDeserializer.java
@@ -14,8 +14,8 @@ import java.util.*;
  *
  * <ol>
  *   <li>Read all string, language, and meta-pointer fields; skip node bodies.
- *   <li>Resolve the index tables, then read only the node fields inline using
- *       {@code pushLimit}/{@code popLimit} — no per-node {@code byte[]} allocation.
+ *   <li>Resolve the index tables, then read only the node fields inline using {@code
+ *       pushLimit}/{@code popLimit} — no per-node {@code byte[]} allocation.
  * </ol>
  *
  * <p>For {@link InputStream} input the stream is first drained into a single {@code byte[]}, then
@@ -178,9 +178,9 @@ final class DirectProtoBufDeserializer {
   // ---- Node decoding ----
 
   /**
-   * Reads a single PBNode body from {@code cis} (already limited by the caller via
-   * {@code pushLimit}) and converts it directly to a {@link SerializedClassifierInstance}.
-   * No intermediate byte[] or CodedInputStream is allocated.
+   * Reads a single PBNode body from {@code cis} (already limited by the caller via {@code
+   * pushLimit}) and converts it directly to a {@link SerializedClassifierInstance}. No intermediate
+   * byte[] or CodedInputStream is allocated.
    */
   private static SerializedClassifierInstance readNodeInline(
       CodedInputStream cis,

--- a/core/src/main/java/io/lionweb/serialization/DirectProtoBufDeserializer.java
+++ b/core/src/main/java/io/lionweb/serialization/DirectProtoBufDeserializer.java
@@ -1,0 +1,315 @@
+package io.lionweb.serialization;
+
+import com.google.protobuf.CodedInputStream;
+import io.lionweb.serialization.data.*;
+import java.io.*;
+import java.util.*;
+
+/**
+ * Deserializes protobuf binary data directly into a {@link SerializationChunk} without creating
+ * intermediate protobuf message objects (PBChunk, PBNode, etc.).
+ *
+ * <p>The wire format is read in two logical passes:
+ *
+ * <ol>
+ *   <li>Read all fields of the top-level PBChunk message: accumulate interned strings inline, store
+ *       raw language/meta-pointer field pairs as {@code int[]}, and buffer each node's body as a
+ *       {@code byte[]}.
+ *   <li>Resolve the index tables (languages then meta-pointers) and decode each buffered node body
+ *       directly into a {@link SerializedClassifierInstance}.
+ * </ol>
+ *
+ * <p>The output is semantically equivalent to what {@code PBChunk.parseFrom(bytes)} followed by
+ * {@code ProtoBufSerialization.deserializeSerializationChunk(pbChunk)} would produce, but avoids
+ * creating any protobuf message objects.
+ *
+ * <p><b>Field ordering assumption:</b> this implementation buffers all node bodies and resolves
+ * tables in a second pass, so fields may appear in any order in the input stream.
+ */
+final class DirectProtoBufDeserializer {
+
+  private DirectProtoBufDeserializer() {}
+
+  // ---- Public entry points ----
+
+  static SerializationChunk deserialize(byte[] bytes, boolean serializeEmptyFeatures)
+      throws IOException {
+    return deserialize(CodedInputStream.newInstance(bytes), serializeEmptyFeatures);
+  }
+
+  static SerializationChunk deserialize(InputStream in, boolean serializeEmptyFeatures)
+      throws IOException {
+    return deserialize(CodedInputStream.newInstance(in), serializeEmptyFeatures);
+  }
+
+  // ---- Core deserialize logic ----
+
+  private static SerializationChunk deserialize(
+      CodedInputStream cis, boolean serializeEmptyFeatures) throws IOException {
+
+    String version = "";
+    // index 0 = null; subsequent entries are the actual interned strings
+    ArrayList<String> strings = new ArrayList<>();
+    strings.add(null);
+
+    // Each int[2] = {siKey, siVersion} (raw string-table indices from the wire)
+    ArrayList<int[]> rawLanguages = new ArrayList<>();
+    // Each int[2] = {liLanguage, siKey} (raw table indices from the wire)
+    ArrayList<int[]> rawMetaPointers = new ArrayList<>();
+    // Raw bytes of each PBNode body (already stripped of the outer tag+length)
+    ArrayList<byte[]> nodeBodyList = new ArrayList<>();
+
+    // Pass 1: read top-level PBChunk fields
+    int tag;
+    while ((tag = cis.readTag()) != 0) {
+      int fieldNumber = tag >>> 3;
+      switch (fieldNumber) {
+        case 1: // serialization_format_version (string)
+          version = cis.readString();
+          break;
+
+        case 2: // interned_strings (repeated string)
+          strings.add(cis.readString());
+          break;
+
+        case 3: // interned_meta_pointers (repeated PBMetaPointer embedded message)
+          {
+            int len = cis.readRawVarint32();
+            int oldLimit = cis.pushLimit(len);
+            int liLanguage = 0, siKey = 0;
+            int innerTag;
+            while ((innerTag = cis.readTag()) != 0) {
+              int f = innerTag >>> 3;
+              if (f == 1) liLanguage = cis.readRawVarint32();
+              else if (f == 2) siKey = cis.readRawVarint32();
+              else cis.skipField(innerTag);
+            }
+            cis.popLimit(oldLimit);
+            rawMetaPointers.add(new int[] {liLanguage, siKey});
+            break;
+          }
+
+        case 4: // interned_languages (repeated PBLanguage embedded message)
+          {
+            int len = cis.readRawVarint32();
+            int oldLimit = cis.pushLimit(len);
+            int siKeyL = 0, siVersionL = 0;
+            int innerTag;
+            while ((innerTag = cis.readTag()) != 0) {
+              int f = innerTag >>> 3;
+              if (f == 1) siKeyL = cis.readRawVarint32();
+              else if (f == 2) siVersionL = cis.readRawVarint32();
+              else cis.skipField(innerTag);
+            }
+            cis.popLimit(oldLimit);
+            rawLanguages.add(new int[] {siKeyL, siVersionL});
+            break;
+          }
+
+        case 5: // nodes (repeated PBNode embedded message) — buffer body bytes
+          {
+            int len = cis.readRawVarint32();
+            nodeBodyList.add(cis.readRawBytes(len));
+            break;
+          }
+
+        default:
+          cis.skipField(tag);
+      }
+    }
+
+    // Pass 2: resolve index tables
+    String[] stringsArray = strings.toArray(new String[0]);
+
+    LanguageVersion[] languagesArray = new LanguageVersion[rawLanguages.size() + 1];
+    languagesArray[0] = null;
+    for (int i = 0; i < rawLanguages.size(); i++) {
+      int[] raw = rawLanguages.get(i);
+      String key = safeGet(stringsArray, raw[0]);
+      String ver = safeGet(stringsArray, raw[1]);
+      languagesArray[i + 1] = LanguageVersion.of(key, ver);
+    }
+
+    MetaPointer[] metaPointersArray = new MetaPointer[rawMetaPointers.size()];
+    for (int i = 0; i < rawMetaPointers.size(); i++) {
+      int[] raw = rawMetaPointers.get(i);
+      LanguageVersion lv = safeGet(languagesArray, raw[0]);
+      String key = safeGet(stringsArray, raw[1]);
+      if (lv != null) {
+        metaPointersArray[i] = MetaPointer.get(lv.getKey(), lv.getVersion(), key);
+      } else {
+        metaPointersArray[i] = MetaPointer.get(null, null, key);
+      }
+    }
+
+    // Pass 3: build SerializationChunk
+    SerializationChunk chunk = new SerializationChunk(nodeBodyList.size());
+    chunk.setSerializationFormatVersion(version);
+    for (int i = 1; i < languagesArray.length; i++) {
+      if (languagesArray[i] != null) chunk.addLanguage(languagesArray[i]);
+    }
+
+    for (byte[] nodeBody : nodeBodyList) {
+      SerializedClassifierInstance sci =
+          readNode(nodeBody, stringsArray, metaPointersArray, serializeEmptyFeatures);
+      chunk.addClassifierInstance(sci);
+    }
+
+    return chunk;
+  }
+
+  // ---- Node decoding ----
+
+  private static SerializedClassifierInstance readNode(
+      byte[] body, String[] strings, MetaPointer[] metaPointers, boolean serializeEmptyFeatures)
+      throws IOException {
+    CodedInputStream cis = CodedInputStream.newInstance(body);
+
+    SerializedClassifierInstance sci = new SerializedClassifierInstance();
+    int siId = 0, mpiClassifier = 0, siParent = 0;
+
+    int tag;
+    while ((tag = cis.readTag()) != 0) {
+      int fieldNumber = tag >>> 3;
+      switch (fieldNumber) {
+        case 1: // si_id
+          siId = cis.readRawVarint32();
+          break;
+
+        case 2: // mpi_classifier
+          mpiClassifier = cis.readRawVarint32();
+          break;
+
+        case 3: // PBProperty embedded message
+          {
+            int len = cis.readRawVarint32();
+            int oldLimit = cis.pushLimit(len);
+            int mpiIndex = 0, siValue = 0;
+            int innerTag;
+            while ((innerTag = cis.readTag()) != 0) {
+              int f = innerTag >>> 3;
+              if (f == 1) mpiIndex = cis.readRawVarint32();
+              else if (f == 2) siValue = cis.readRawVarint32();
+              else cis.skipField(innerTag);
+            }
+            cis.popLimit(oldLimit);
+            if (serializeEmptyFeatures || siValue != 0) {
+              MetaPointer mp = safeGet(metaPointers, mpiIndex);
+              String value = safeGet(strings, siValue);
+              sci.unsafeAppendPropertyValue(SerializedPropertyValue.get(mp, value));
+            }
+            break;
+          }
+
+        case 4: // PBContainment embedded message
+          {
+            int len = cis.readRawVarint32();
+            int oldLimit = cis.pushLimit(len);
+            int mpiIndex = 0;
+            List<String> children = null;
+            int innerTag;
+            while ((innerTag = cis.readTag()) != 0) {
+              int f = innerTag >>> 3;
+              if (f == 1) {
+                mpiIndex = cis.readRawVarint32();
+              } else if (f == 2) {
+                // packed repeated uint32 si_children
+                int packedLen = cis.readRawVarint32();
+                int packedOldLimit = cis.pushLimit(packedLen);
+                children = new ArrayList<>();
+                while (!cis.isAtEnd()) {
+                  int childIdx = cis.readRawVarint32();
+                  if (childIdx == 0) {
+                    throw new DeserializationException(
+                        "Unable to deserialize child identified by Null ID");
+                  }
+                  children.add(safeGet(strings, childIdx));
+                }
+                cis.popLimit(packedOldLimit);
+              } else {
+                cis.skipField(innerTag);
+              }
+            }
+            cis.popLimit(oldLimit);
+            if (children == null) children = Collections.emptyList();
+            if (serializeEmptyFeatures || !children.isEmpty()) {
+              MetaPointer mp = safeGet(metaPointers, mpiIndex);
+              sci.unsafeAppendContainmentValue(new SerializedContainmentValue(mp, children));
+            }
+            break;
+          }
+
+        case 5: // PBReference embedded message
+          {
+            int len = cis.readRawVarint32();
+            int oldLimit = cis.pushLimit(len);
+            int mpiIndex = 0;
+            List<SerializedReferenceValue.Entry> entries = new ArrayList<>();
+            int innerTag;
+            while ((innerTag = cis.readTag()) != 0) {
+              int f = innerTag >>> 3;
+              if (f == 1) {
+                mpiIndex = cis.readRawVarint32();
+              } else if (f == 2) {
+                // PBReferenceValue embedded message
+                int rvLen = cis.readRawVarint32();
+                int rvOldLimit = cis.pushLimit(rvLen);
+                int siResolveInfo = 0, siReferred = 0;
+                int rvTag;
+                while ((rvTag = cis.readTag()) != 0) {
+                  int rf = rvTag >>> 3;
+                  if (rf == 1) siResolveInfo = cis.readRawVarint32();
+                  else if (rf == 2) siReferred = cis.readRawVarint32();
+                  else cis.skipField(rvTag);
+                }
+                cis.popLimit(rvOldLimit);
+                SerializedReferenceValue.Entry entry = new SerializedReferenceValue.Entry();
+                entry.setReference(safeGet(strings, siReferred));
+                entry.setResolveInfo(safeGet(strings, siResolveInfo));
+                entries.add(entry);
+              } else {
+                cis.skipField(innerTag);
+              }
+            }
+            cis.popLimit(oldLimit);
+            if (serializeEmptyFeatures || !entries.isEmpty()) {
+              MetaPointer mp = safeGet(metaPointers, mpiIndex);
+              sci.unsafeAppendReferenceValue(new SerializedReferenceValue(mp, entries));
+            }
+            break;
+          }
+
+        case 6: // si_annotations (packed repeated uint32)
+          {
+            int len = cis.readRawVarint32();
+            int oldLimit = cis.pushLimit(len);
+            while (!cis.isAtEnd()) {
+              int annIdx = cis.readRawVarint32();
+              sci.addAnnotation(safeGet(strings, annIdx));
+            }
+            cis.popLimit(oldLimit);
+            break;
+          }
+
+        case 7: // si_parent
+          siParent = cis.readRawVarint32();
+          break;
+
+        default:
+          cis.skipField(tag);
+      }
+    }
+
+    sci.setID(safeGet(strings, siId));
+    sci.setClassifier(safeGet(metaPointers, mpiClassifier));
+    sci.setParentNodeID(safeGet(strings, siParent));
+
+    return sci;
+  }
+
+  // ---- Helpers ----
+
+  private static <T> T safeGet(T[] array, int index) {
+    return (index >= 0 && index < array.length) ? array[index] : null;
+  }
+}

--- a/core/src/main/java/io/lionweb/serialization/DirectProtoBufDeserializer.java
+++ b/core/src/main/java/io/lionweb/serialization/DirectProtoBufDeserializer.java
@@ -9,22 +9,21 @@ import java.util.*;
  * Deserializes protobuf binary data directly into a {@link SerializationChunk} without creating
  * intermediate protobuf message objects (PBChunk, PBNode, etc.).
  *
- * <p>The wire format is read in two logical passes:
+ * <p>For {@code byte[]} input the implementation uses two passes over the <em>same</em> backing
+ * array (no copy):
  *
  * <ol>
- *   <li>Read all fields of the top-level PBChunk message: accumulate interned strings inline, store
- *       raw language/meta-pointer field pairs as {@code int[]}, and buffer each node's body as a
- *       {@code byte[]}.
- *   <li>Resolve the index tables (languages then meta-pointers) and decode each buffered node body
- *       directly into a {@link SerializedClassifierInstance}.
+ *   <li>Read all string, language, and meta-pointer fields; skip node bodies.
+ *   <li>Resolve the index tables, then read only the node fields inline using
+ *       {@code pushLimit}/{@code popLimit} — no per-node {@code byte[]} allocation.
  * </ol>
+ *
+ * <p>For {@link InputStream} input the stream is first drained into a single {@code byte[]}, then
+ * the same two-pass strategy is applied.
  *
  * <p>The output is semantically equivalent to what {@code PBChunk.parseFrom(bytes)} followed by
  * {@code ProtoBufSerialization.deserializeSerializationChunk(pbChunk)} would produce, but avoids
  * creating any protobuf message objects.
- *
- * <p><b>Field ordering assumption:</b> this implementation buffers all node bodies and resolves
- * tables in a second pass, so fields may appear in any order in the input stream.
  */
 final class DirectProtoBufDeserializer {
 
@@ -34,107 +33,116 @@ final class DirectProtoBufDeserializer {
 
   static SerializationChunk deserialize(byte[] bytes, boolean serializeEmptyFeatures)
       throws IOException {
-    return deserialize(CodedInputStream.newInstance(bytes), serializeEmptyFeatures);
+    return deserializeTwoPass(bytes, serializeEmptyFeatures);
   }
 
   static SerializationChunk deserialize(InputStream in, boolean serializeEmptyFeatures)
       throws IOException {
-    return deserialize(CodedInputStream.newInstance(in), serializeEmptyFeatures);
+    // Drain to a single byte[] so we can apply the same two-pass optimisation.
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    byte[] buf = new byte[8192];
+    int n;
+    while ((n = in.read(buf)) != -1) baos.write(buf, 0, n);
+    return deserializeTwoPass(baos.toByteArray(), serializeEmptyFeatures);
   }
 
-  // ---- Core deserialize logic ----
+  // ---- Two-pass core ----
 
-  private static SerializationChunk deserialize(
-      CodedInputStream cis, boolean serializeEmptyFeatures) throws IOException {
+  private static SerializationChunk deserializeTwoPass(byte[] bytes, boolean serializeEmptyFeatures)
+      throws IOException {
 
     String version = "";
-    // index 0 = null; subsequent entries are the actual interned strings
+    // index 0 = null; actual strings start at index 1
     ArrayList<String> strings = new ArrayList<>();
     strings.add(null);
 
-    // Each int[2] = {siKey, siVersion} (raw string-table indices from the wire)
-    ArrayList<int[]> rawLanguages = new ArrayList<>();
-    // Each int[2] = {liLanguage, siKey} (raw table indices from the wire)
-    ArrayList<int[]> rawMetaPointers = new ArrayList<>();
-    // Raw bytes of each PBNode body (already stripped of the outer tag+length)
-    ArrayList<byte[]> nodeBodyList = new ArrayList<>();
+    // Flat int arrays for compact storage: langData[2i]=siKey, langData[2i+1]=siVersion
+    int[] langData = new int[16];
+    int langCount = 0;
 
-    // Pass 1: read top-level PBChunk fields
+    // mpData[2i]=liLanguage, mpData[2i+1]=siKey
+    int[] mpData = new int[32];
+    int mpCount = 0;
+
+    // Pass 1: read strings / languages / meta-pointers; skip node bodies
+    CodedInputStream cis = CodedInputStream.newInstance(bytes);
     int tag;
     while ((tag = cis.readTag()) != 0) {
-      int fieldNumber = tag >>> 3;
-      switch (fieldNumber) {
-        case 1: // serialization_format_version (string)
+      int f = tag >>> 3;
+      switch (f) {
+        case 1: // serialization_format_version
           version = cis.readString();
           break;
 
-        case 2: // interned_strings (repeated string)
+        case 2: // interned_strings
           strings.add(cis.readString());
           break;
 
-        case 3: // interned_meta_pointers (repeated PBMetaPointer embedded message)
+        case 3: // interned_meta_pointers
           {
             int len = cis.readRawVarint32();
             int oldLimit = cis.pushLimit(len);
             int liLanguage = 0, siKey = 0;
             int innerTag;
             while ((innerTag = cis.readTag()) != 0) {
-              int f = innerTag >>> 3;
-              if (f == 1) liLanguage = cis.readRawVarint32();
-              else if (f == 2) siKey = cis.readRawVarint32();
+              int fi = innerTag >>> 3;
+              if (fi == 1) liLanguage = cis.readRawVarint32();
+              else if (fi == 2) siKey = cis.readRawVarint32();
               else cis.skipField(innerTag);
             }
             cis.popLimit(oldLimit);
-            rawMetaPointers.add(new int[] {liLanguage, siKey});
+            if (mpCount * 2 >= mpData.length) mpData = Arrays.copyOf(mpData, mpData.length * 2);
+            mpData[mpCount * 2] = liLanguage;
+            mpData[mpCount * 2 + 1] = siKey;
+            mpCount++;
             break;
           }
 
-        case 4: // interned_languages (repeated PBLanguage embedded message)
+        case 4: // interned_languages
           {
             int len = cis.readRawVarint32();
             int oldLimit = cis.pushLimit(len);
             int siKeyL = 0, siVersionL = 0;
             int innerTag;
             while ((innerTag = cis.readTag()) != 0) {
-              int f = innerTag >>> 3;
-              if (f == 1) siKeyL = cis.readRawVarint32();
-              else if (f == 2) siVersionL = cis.readRawVarint32();
+              int fi = innerTag >>> 3;
+              if (fi == 1) siKeyL = cis.readRawVarint32();
+              else if (fi == 2) siVersionL = cis.readRawVarint32();
               else cis.skipField(innerTag);
             }
             cis.popLimit(oldLimit);
-            rawLanguages.add(new int[] {siKeyL, siVersionL});
+            if (langCount * 2 >= langData.length)
+              langData = Arrays.copyOf(langData, langData.length * 2);
+            langData[langCount * 2] = siKeyL;
+            langData[langCount * 2 + 1] = siVersionL;
+            langCount++;
             break;
           }
 
-        case 5: // nodes (repeated PBNode embedded message) — buffer body bytes
-          {
-            int len = cis.readRawVarint32();
-            nodeBodyList.add(cis.readRawBytes(len));
-            break;
-          }
+        case 5: // nodes — skip in pass 1
+          cis.skipField(tag);
+          break;
 
         default:
           cis.skipField(tag);
       }
     }
 
-    // Pass 2: resolve index tables
-    String[] stringsArray = strings.toArray(new String[0]);
+    // Resolve index tables
+    String[] stringsArray = strings.toArray(new String[strings.size()]);
 
-    LanguageVersion[] languagesArray = new LanguageVersion[rawLanguages.size() + 1];
+    LanguageVersion[] languagesArray = new LanguageVersion[langCount + 1];
     languagesArray[0] = null;
-    for (int i = 0; i < rawLanguages.size(); i++) {
-      int[] raw = rawLanguages.get(i);
-      String key = safeGet(stringsArray, raw[0]);
-      String ver = safeGet(stringsArray, raw[1]);
+    for (int i = 0; i < langCount; i++) {
+      String key = safeGet(stringsArray, langData[i * 2]);
+      String ver = safeGet(stringsArray, langData[i * 2 + 1]);
       languagesArray[i + 1] = LanguageVersion.of(key, ver);
     }
 
-    MetaPointer[] metaPointersArray = new MetaPointer[rawMetaPointers.size()];
-    for (int i = 0; i < rawMetaPointers.size(); i++) {
-      int[] raw = rawMetaPointers.get(i);
-      LanguageVersion lv = safeGet(languagesArray, raw[0]);
-      String key = safeGet(stringsArray, raw[1]);
+    MetaPointer[] metaPointersArray = new MetaPointer[mpCount];
+    for (int i = 0; i < mpCount; i++) {
+      LanguageVersion lv = safeGet(languagesArray, mpData[i * 2]);
+      String key = safeGet(stringsArray, mpData[i * 2 + 1]);
       if (lv != null) {
         metaPointersArray[i] = MetaPointer.get(lv.getKey(), lv.getVersion(), key);
       } else {
@@ -142,17 +150,26 @@ final class DirectProtoBufDeserializer {
       }
     }
 
-    // Pass 3: build SerializationChunk
-    SerializationChunk chunk = new SerializationChunk(nodeBodyList.size());
+    // Build chunk header
+    SerializationChunk chunk = new SerializationChunk();
     chunk.setSerializationFormatVersion(version);
     for (int i = 1; i < languagesArray.length; i++) {
       if (languagesArray[i] != null) chunk.addLanguage(languagesArray[i]);
     }
 
-    for (byte[] nodeBody : nodeBodyList) {
-      SerializedClassifierInstance sci =
-          readNode(nodeBody, stringsArray, metaPointersArray, serializeEmptyFeatures);
-      chunk.addClassifierInstance(sci);
+    // Pass 2: second pass over the same byte[] (no copy) — parse only node fields inline
+    cis = CodedInputStream.newInstance(bytes);
+    while ((tag = cis.readTag()) != 0) {
+      int f = tag >>> 3;
+      if (f == 5) {
+        int len = cis.readRawVarint32();
+        int oldLimit = cis.pushLimit(len);
+        chunk.addClassifierInstance(
+            readNodeInline(cis, stringsArray, metaPointersArray, serializeEmptyFeatures));
+        cis.popLimit(oldLimit);
+      } else {
+        cis.skipField(tag);
+      }
     }
 
     return chunk;
@@ -160,10 +177,17 @@ final class DirectProtoBufDeserializer {
 
   // ---- Node decoding ----
 
-  private static SerializedClassifierInstance readNode(
-      byte[] body, String[] strings, MetaPointer[] metaPointers, boolean serializeEmptyFeatures)
+  /**
+   * Reads a single PBNode body from {@code cis} (already limited by the caller via
+   * {@code pushLimit}) and converts it directly to a {@link SerializedClassifierInstance}.
+   * No intermediate byte[] or CodedInputStream is allocated.
+   */
+  private static SerializedClassifierInstance readNodeInline(
+      CodedInputStream cis,
+      String[] strings,
+      MetaPointer[] metaPointers,
+      boolean serializeEmptyFeatures)
       throws IOException {
-    CodedInputStream cis = CodedInputStream.newInstance(body);
 
     SerializedClassifierInstance sci = new SerializedClassifierInstance();
     int siId = 0, mpiClassifier = 0, siParent = 0;
@@ -187,9 +211,9 @@ final class DirectProtoBufDeserializer {
             int mpiIndex = 0, siValue = 0;
             int innerTag;
             while ((innerTag = cis.readTag()) != 0) {
-              int f = innerTag >>> 3;
-              if (f == 1) mpiIndex = cis.readRawVarint32();
-              else if (f == 2) siValue = cis.readRawVarint32();
+              int fi = innerTag >>> 3;
+              if (fi == 1) mpiIndex = cis.readRawVarint32();
+              else if (fi == 2) siValue = cis.readRawVarint32();
               else cis.skipField(innerTag);
             }
             cis.popLimit(oldLimit);
@@ -209,10 +233,10 @@ final class DirectProtoBufDeserializer {
             List<String> children = null;
             int innerTag;
             while ((innerTag = cis.readTag()) != 0) {
-              int f = innerTag >>> 3;
-              if (f == 1) {
+              int fi = innerTag >>> 3;
+              if (fi == 1) {
                 mpiIndex = cis.readRawVarint32();
-              } else if (f == 2) {
+              } else if (fi == 2) {
                 // packed repeated uint32 si_children
                 int packedLen = cis.readRawVarint32();
                 int packedOldLimit = cis.pushLimit(packedLen);
@@ -247,10 +271,10 @@ final class DirectProtoBufDeserializer {
             List<SerializedReferenceValue.Entry> entries = new ArrayList<>();
             int innerTag;
             while ((innerTag = cis.readTag()) != 0) {
-              int f = innerTag >>> 3;
-              if (f == 1) {
+              int fi = innerTag >>> 3;
+              if (fi == 1) {
                 mpiIndex = cis.readRawVarint32();
-              } else if (f == 2) {
+              } else if (fi == 2) {
                 // PBReferenceValue embedded message
                 int rvLen = cis.readRawVarint32();
                 int rvOldLimit = cis.pushLimit(rvLen);
@@ -309,6 +333,7 @@ final class DirectProtoBufDeserializer {
 
   // ---- Helpers ----
 
+  @SuppressWarnings("unchecked")
   private static <T> T safeGet(T[] array, int index) {
     return (index >= 0 && index < array.length) ? array[index] : null;
   }

--- a/core/src/main/java/io/lionweb/serialization/DirectProtoBufDeserializer.java
+++ b/core/src/main/java/io/lionweb/serialization/DirectProtoBufDeserializer.java
@@ -8,28 +8,25 @@ import java.util.*;
 /**
  * Deserializes protobuf binary data directly into a {@link SerializationChunk} without creating
  * intermediate protobuf message objects (PBChunk, PBNode, etc.).
- *
- * <p>For {@code byte[]} input the implementation uses two passes over the <em>same</em> backing
- * array (no copy):
- *
- * <ol>
- *   <li>Read all string, language, and meta-pointer fields; skip node bodies.
- *   <li>Resolve the index tables, then read only the node fields inline using {@code
- *       pushLimit}/{@code popLimit} — no per-node {@code byte[]} allocation.
- * </ol>
- *
- * <p>For {@link InputStream} input the stream is first drained into a single {@code byte[]}, then
- * the same two-pass strategy is applied.
- *
- * <p>The output is semantically equivalent to what {@code PBChunk.parseFrom(bytes)} followed by
- * {@code ProtoBufSerialization.deserializeSerializationChunk(pbChunk)} would produce, but avoids
- * creating any protobuf message objects.
  */
 final class DirectProtoBufDeserializer {
+  // <p>For {@code byte[]} input the implementation uses two passes over the <em>same</em> backing
+  // array (no copy):
+  //
+  // <ol>
+  //   <li>Read all string, language, and meta-pointer fields; skip node bodies.
+  //   <li>Resolve the index tables, then read only the node fields inline using {@code
+  //       pushLimit}/{@code popLimit} — no per-node {@code byte[]} allocation.
+  // </ol>
+  //
+  // <p>For {@link InputStream} input the stream is first drained into a single {@code byte[]}, then
+  // the same two-pass strategy is applied.
+  //
+  // <p>The output is semantically equivalent to what {@code PBChunk.parseFrom(bytes)} followed by
+  // {@code ProtoBufSerialization.deserializeSerializationChunk(pbChunk)} would produce, but avoids
+  // creating any protobuf message objects.
 
   private DirectProtoBufDeserializer() {}
-
-  // ---- Public entry points ----
 
   static SerializationChunk deserialize(byte[] bytes, boolean serializeEmptyFeatures)
       throws IOException {
@@ -45,8 +42,6 @@ final class DirectProtoBufDeserializer {
     while ((n = in.read(buf)) != -1) baos.write(buf, 0, n);
     return deserializeTwoPass(baos.toByteArray(), serializeEmptyFeatures);
   }
-
-  // ---- Two-pass core ----
 
   private static SerializationChunk deserializeTwoPass(byte[] bytes, boolean serializeEmptyFeatures)
       throws IOException {
@@ -111,8 +106,9 @@ final class DirectProtoBufDeserializer {
               else cis.skipField(innerTag);
             }
             cis.popLimit(oldLimit);
-            if (langCount * 2 >= langData.length)
+            if (langCount * 2 >= langData.length) {
               langData = Arrays.copyOf(langData, langData.length * 2);
+            }
             langData[langCount * 2] = siKeyL;
             langData[langCount * 2 + 1] = siVersionL;
             langCount++;

--- a/core/src/main/java/io/lionweb/serialization/DirectProtoBufDeserializer.java
+++ b/core/src/main/java/io/lionweb/serialization/DirectProtoBufDeserializer.java
@@ -1,5 +1,7 @@
 package io.lionweb.serialization;
 
+import static io.lionweb.serialization.ProtoBufFieldNumbers.*;
+
 import com.google.protobuf.CodedInputStream;
 import io.lionweb.serialization.data.*;
 import java.io.*;
@@ -65,15 +67,15 @@ final class DirectProtoBufDeserializer {
     while ((tag = cis.readTag()) != 0) {
       int f = tag >>> 3;
       switch (f) {
-        case 1: // serialization_format_version
+        case CHUNK_SERIALIZATION_FORMAT_VERSION:
           version = cis.readString();
           break;
 
-        case 2: // interned_strings
+        case CHUNK_INTERNED_STRINGS:
           strings.add(cis.readString());
           break;
 
-        case 3: // interned_meta_pointers
+        case CHUNK_INTERNED_META_POINTERS:
           {
             int len = cis.readRawVarint32();
             int oldLimit = cis.pushLimit(len);
@@ -81,8 +83,8 @@ final class DirectProtoBufDeserializer {
             int innerTag;
             while ((innerTag = cis.readTag()) != 0) {
               int fi = innerTag >>> 3;
-              if (fi == 1) liLanguage = cis.readRawVarint32();
-              else if (fi == 2) siKey = cis.readRawVarint32();
+              if (fi == META_POINTER_LI_LANGUAGE) liLanguage = cis.readRawVarint32();
+              else if (fi == META_POINTER_SI_KEY) siKey = cis.readRawVarint32();
               else cis.skipField(innerTag);
             }
             cis.popLimit(oldLimit);
@@ -93,7 +95,7 @@ final class DirectProtoBufDeserializer {
             break;
           }
 
-        case 4: // interned_languages
+        case CHUNK_INTERNED_LANGUAGES:
           {
             int len = cis.readRawVarint32();
             int oldLimit = cis.pushLimit(len);
@@ -101,8 +103,8 @@ final class DirectProtoBufDeserializer {
             int innerTag;
             while ((innerTag = cis.readTag()) != 0) {
               int fi = innerTag >>> 3;
-              if (fi == 1) siKeyL = cis.readRawVarint32();
-              else if (fi == 2) siVersionL = cis.readRawVarint32();
+              if (fi == LANGUAGE_SI_KEY) siKeyL = cis.readRawVarint32();
+              else if (fi == LANGUAGE_SI_VERSION) siVersionL = cis.readRawVarint32();
               else cis.skipField(innerTag);
             }
             cis.popLimit(oldLimit);
@@ -115,7 +117,7 @@ final class DirectProtoBufDeserializer {
             break;
           }
 
-        case 5: // nodes — skip in pass 1
+        case CHUNK_NODES: // skip in pass 1
           cis.skipField(tag);
           break;
 
@@ -157,7 +159,7 @@ final class DirectProtoBufDeserializer {
     cis = CodedInputStream.newInstance(bytes);
     while ((tag = cis.readTag()) != 0) {
       int f = tag >>> 3;
-      if (f == 5) {
+      if (f == CHUNK_NODES) {
         int len = cis.readRawVarint32();
         int oldLimit = cis.pushLimit(len);
         chunk.addClassifierInstance(
@@ -192,15 +194,15 @@ final class DirectProtoBufDeserializer {
     while ((tag = cis.readTag()) != 0) {
       int fieldNumber = tag >>> 3;
       switch (fieldNumber) {
-        case 1: // si_id
+        case NODE_SI_ID:
           siId = cis.readRawVarint32();
           break;
 
-        case 2: // mpi_classifier
+        case NODE_MPI_CLASSIFIER:
           mpiClassifier = cis.readRawVarint32();
           break;
 
-        case 3: // PBProperty embedded message
+        case NODE_PROPERTIES: // PBProperty embedded message
           {
             int len = cis.readRawVarint32();
             int oldLimit = cis.pushLimit(len);
@@ -208,8 +210,8 @@ final class DirectProtoBufDeserializer {
             int innerTag;
             while ((innerTag = cis.readTag()) != 0) {
               int fi = innerTag >>> 3;
-              if (fi == 1) mpiIndex = cis.readRawVarint32();
-              else if (fi == 2) siValue = cis.readRawVarint32();
+              if (fi == PROPERTY_MPI) mpiIndex = cis.readRawVarint32();
+              else if (fi == PROPERTY_SI_VALUE) siValue = cis.readRawVarint32();
               else cis.skipField(innerTag);
             }
             cis.popLimit(oldLimit);
@@ -221,7 +223,7 @@ final class DirectProtoBufDeserializer {
             break;
           }
 
-        case 4: // PBContainment embedded message
+        case NODE_CONTAINMENTS: // PBContainment embedded message
           {
             int len = cis.readRawVarint32();
             int oldLimit = cis.pushLimit(len);
@@ -230,9 +232,9 @@ final class DirectProtoBufDeserializer {
             int innerTag;
             while ((innerTag = cis.readTag()) != 0) {
               int fi = innerTag >>> 3;
-              if (fi == 1) {
+              if (fi == CONTAINMENT_MPI) {
                 mpiIndex = cis.readRawVarint32();
-              } else if (fi == 2) {
+              } else if (fi == CONTAINMENT_SI_CHILDREN) {
                 // packed repeated uint32 si_children
                 int packedLen = cis.readRawVarint32();
                 int packedOldLimit = cis.pushLimit(packedLen);
@@ -259,7 +261,7 @@ final class DirectProtoBufDeserializer {
             break;
           }
 
-        case 5: // PBReference embedded message
+        case NODE_REFERENCES: // PBReference embedded message
           {
             int len = cis.readRawVarint32();
             int oldLimit = cis.pushLimit(len);
@@ -268,9 +270,9 @@ final class DirectProtoBufDeserializer {
             int innerTag;
             while ((innerTag = cis.readTag()) != 0) {
               int fi = innerTag >>> 3;
-              if (fi == 1) {
+              if (fi == REFERENCE_MPI) {
                 mpiIndex = cis.readRawVarint32();
-              } else if (fi == 2) {
+              } else if (fi == REFERENCE_ENTRIES) {
                 // PBReferenceValue embedded message
                 int rvLen = cis.readRawVarint32();
                 int rvOldLimit = cis.pushLimit(rvLen);
@@ -278,8 +280,8 @@ final class DirectProtoBufDeserializer {
                 int rvTag;
                 while ((rvTag = cis.readTag()) != 0) {
                   int rf = rvTag >>> 3;
-                  if (rf == 1) siResolveInfo = cis.readRawVarint32();
-                  else if (rf == 2) siReferred = cis.readRawVarint32();
+                  if (rf == REFERENCE_VALUE_SI_RESOLVE_INFO) siResolveInfo = cis.readRawVarint32();
+                  else if (rf == REFERENCE_VALUE_SI_REFERRED) siReferred = cis.readRawVarint32();
                   else cis.skipField(rvTag);
                 }
                 cis.popLimit(rvOldLimit);
@@ -301,7 +303,7 @@ final class DirectProtoBufDeserializer {
             break;
           }
 
-        case 6: // si_annotations (packed repeated uint32)
+        case NODE_SI_ANNOTATIONS: // packed repeated uint32
           {
             int len = cis.readRawVarint32();
             int oldLimit = cis.pushLimit(len);
@@ -313,7 +315,7 @@ final class DirectProtoBufDeserializer {
             break;
           }
 
-        case 7: // si_parent
+        case NODE_SI_PARENT:
           siParent = cis.readRawVarint32();
           break;
 

--- a/core/src/main/java/io/lionweb/serialization/DirectProtoBufDeserializer.java
+++ b/core/src/main/java/io/lionweb/serialization/DirectProtoBufDeserializer.java
@@ -240,7 +240,7 @@ final class DirectProtoBufDeserializer {
                 // packed repeated uint32 si_children
                 int packedLen = cis.readRawVarint32();
                 int packedOldLimit = cis.pushLimit(packedLen);
-                children = new ArrayList<>();
+                children = new ArrayList<>(Math.max(4, packedLen));
                 while (!cis.isAtEnd()) {
                   int childIdx = cis.readRawVarint32();
                   if (childIdx == 0) {
@@ -268,7 +268,7 @@ final class DirectProtoBufDeserializer {
             int len = cis.readRawVarint32();
             int oldLimit = cis.pushLimit(len);
             int mpiIndex = 0;
-            List<SerializedReferenceValue.Entry> entries = new ArrayList<>();
+            List<SerializedReferenceValue.Entry> entries = null;
             int innerTag;
             while ((innerTag = cis.readTag()) != 0) {
               int fi = innerTag >>> 3;
@@ -287,6 +287,7 @@ final class DirectProtoBufDeserializer {
                   else cis.skipField(rvTag);
                 }
                 cis.popLimit(rvOldLimit);
+                if (entries == null) entries = new ArrayList<>();
                 SerializedReferenceValue.Entry entry = new SerializedReferenceValue.Entry();
                 entry.setReference(safeGet(strings, siReferred));
                 entry.setResolveInfo(safeGet(strings, siResolveInfo));
@@ -296,6 +297,7 @@ final class DirectProtoBufDeserializer {
               }
             }
             cis.popLimit(oldLimit);
+            if (entries == null) entries = Collections.emptyList();
             if (serializeEmptyFeatures || !entries.isEmpty()) {
               MetaPointer mp = safeGet(metaPointers, mpiIndex);
               sci.unsafeAppendReferenceValue(new SerializedReferenceValue(mp, entries));

--- a/core/src/main/java/io/lionweb/serialization/DirectProtoBufSerializer.java
+++ b/core/src/main/java/io/lionweb/serialization/DirectProtoBufSerializer.java
@@ -13,8 +13,9 @@ import java.util.*;
  * <p>The two-pass strategy:
  *
  * <ol>
- *   <li>Visit every node to populate the interned string / language / meta-pointer index tables.
- *   <li>Compute the exact serialized byte count bottom-up (no intermediate byte arrays).
+ *   <li>Visit every node to populate the interned string / language / meta-pointer index tables
+ *       <em>and</em> compute each node's serialized body size in the same traversal.
+ *   <li>Compute the exact total byte count from the index tables plus the pre-computed node sizes.
  *   <li>Allocate a single {@code byte[]} and write all fields in one shot via {@link
  *       CodedOutputStream}.
  * </ol>
@@ -36,15 +37,16 @@ final class DirectProtoBufSerializer {
    * @return the protobuf-encoded bytes
    */
   static byte[] serialize(SerializationChunk chunk, boolean serializeEmptyFeatures) {
-    SerializeState state = buildIndexTables(chunk, serializeEmptyFeatures);
+    SerializeState state = new SerializeState();
     List<SerializedClassifierInstance> instances = chunk.getClassifierInstances();
 
-    // Pre-compute every node body size once; reused in both computeChunkSize and writeChunk
-    // to avoid visiting each node twice.
+    // Single pass: build index tables AND compute each node's body size simultaneously.
     int[] nodeBodySizes = new int[instances.size()];
-    int totalSize =
-        computeChunkSize(chunk, state, instances, nodeBodySizes, serializeEmptyFeatures);
+    for (int i = 0; i < instances.size(); i++) {
+      nodeBodySizes[i] = visitAndComputeBodySize(state, instances.get(i), serializeEmptyFeatures);
+    }
 
+    int totalSize = computeChunkSize(chunk, state, nodeBodySizes);
     byte[] result = new byte[totalSize];
     CodedOutputStream cos = CodedOutputStream.newInstance(result);
     try {
@@ -108,56 +110,90 @@ final class DirectProtoBufSerializer {
     }
   }
 
-  private static SerializeState buildIndexTables(
-      SerializationChunk chunk, boolean serializeEmptyFeatures) {
-    SerializeState state = new SerializeState();
-    for (SerializedClassifierInstance instance : chunk.getClassifierInstances()) {
-      visitNode(state, instance, serializeEmptyFeatures);
-    }
-    return state;
-  }
-
-  private static void visitNode(
+  /**
+   * Visits {@code n} to populate index tables AND returns the node's serialized body size in a
+   * single traversal, eliminating a separate size-computation pass.
+   *
+   * <p>Field indexing order matches the legacy {@code SerializeHelper.serializeNode} exactly so
+   * that string/language/meta-pointer table indices — and therefore the output bytes — are
+   * identical.
+   */
+  private static int visitAndComputeBodySize(
       SerializeState state, SerializedClassifierInstance n, boolean serializeEmptyFeatures) {
-    if (n.getID() != null) state.stringIndexer(n.getID());
-    if (n.getParentNodeID() != null) state.stringIndexer(n.getParentNodeID());
-    if (n.getClassifier() != null) state.metaPointerIndexer(n.getClassifier());
+    int size = 0;
 
+    // field 1: si_id
+    if (n.getID() != null) size += uint32FieldSize(state.stringIndexer(n.getID()));
+
+    // field 7: si_parent — indexed here to match legacy ordering; size contributed below
+    int siParent = n.getParentNodeID() != null ? state.stringIndexer(n.getParentNodeID()) : 0;
+
+    // field 2: mpi_classifier
+    if (n.getClassifier() != null)
+      size += uint32FieldSize(state.metaPointerIndexer(n.getClassifier()));
+
+    // field 3: properties
     for (SerializedPropertyValue p : n.getProperties()) {
       String value = p.getValue();
       if (serializeEmptyFeatures || value != null) {
-        // Match legacy SerializeHelper: value string is indexed BEFORE the meta-pointer
-        state.stringIndexer(value); // null-safe: returns 0 and adds nothing when null
-        if (p.getMetaPointer() != null) state.metaPointerIndexer(p.getMetaPointer());
+        // Match legacy SerializeHelper: value string indexed BEFORE meta-pointer
+        int siValue = state.stringIndexer(value);
+        int mpiIndex =
+            p.getMetaPointer() != null ? state.metaPointerIndexer(p.getMetaPointer()) : 0;
+        int bodySize = uint32FieldSize(mpiIndex) + uint32FieldSize(siValue);
+        size += 1 + varintSize(bodySize) + bodySize;
       }
     }
 
+    // field 4: containments
     for (SerializedContainmentValue c : n.getContainments()) {
       List<String> children = c.getChildrenIds();
       if (serializeEmptyFeatures || !children.isEmpty()) {
-        if (c.getMetaPointer() != null) state.metaPointerIndexer(c.getMetaPointer());
-        for (String childId : children) state.stringIndexer(childId);
+        int mpiIndex =
+            c.getMetaPointer() != null ? state.metaPointerIndexer(c.getMetaPointer()) : 0;
+        int packed = 0;
+        for (String childId : children) packed += varintSize(state.stringIndexer(childId));
+        int packedFieldSize = children.isEmpty() ? 0 : (1 + varintSize(packed) + packed);
+        int bodySize = uint32FieldSize(mpiIndex) + packedFieldSize;
+        size += 1 + varintSize(bodySize) + bodySize;
       }
     }
 
+    // field 5: references
     for (SerializedReferenceValue r : n.getReferences()) {
       List<SerializedReferenceValue.Entry> entries = r.getValue();
       if (serializeEmptyFeatures || !entries.isEmpty()) {
-        if (r.getMetaPointer() != null) state.metaPointerIndexer(r.getMetaPointer());
+        int mpiIndex =
+            r.getMetaPointer() != null ? state.metaPointerIndexer(r.getMetaPointer()) : 0;
+        int refBodySize = uint32FieldSize(mpiIndex);
         for (SerializedReferenceValue.Entry entry : entries) {
           // Match legacy: referred indexed before resolveInfo
-          if (entry.getReference() != null) state.stringIndexer(entry.getReference());
-          if (entry.getResolveInfo() != null) state.stringIndexer(entry.getResolveInfo());
+          int siReferred =
+              entry.getReference() != null ? state.stringIndexer(entry.getReference()) : 0;
+          int siResolveInfo =
+              entry.getResolveInfo() != null ? state.stringIndexer(entry.getResolveInfo()) : 0;
+          int rvBody = referenceValueBodySize(siResolveInfo, siReferred);
+          refBodySize += 1 + varintSize(rvBody) + rvBody;
         }
+        size += 1 + varintSize(refBodySize) + refBodySize;
       }
     }
 
-    for (String annId : n.getAnnotations()) {
-      if (annId != null) state.stringIndexer(annId);
+    // field 6: si_annotations (packed)
+    List<String> annotations = n.getAnnotations();
+    if (!annotations.isEmpty()) {
+      int packed = 0;
+      for (String annId : annotations) packed += varintSize(state.stringIndexer(annId));
+      size += 1 + varintSize(packed) + packed;
     }
+
+    // field 7: si_parent size (index already computed above to preserve table-population order)
+    size += uint32FieldSize(siParent);
+
+    return size;
   }
 
-  // ---- Size computation (Phase 2) ----
+  // ---- Size helpers ----
 
   /** UTF-8 byte count for {@code s} without allocating a byte array. */
   static int utf8ByteCount(String s) {
@@ -210,115 +246,13 @@ final class DirectProtoBufSerializer {
     return uint32FieldSize(siKey) + uint32FieldSize(siVersion);
   }
 
-  private static int propertyBodySize(int mpiIndex, int siValue) {
-    return uint32FieldSize(mpiIndex) + uint32FieldSize(siValue);
-  }
-
-  private static int packedChildrenSize(List<String> children, SerializeState state) {
-    if (children.isEmpty()) return 0;
-    int packed = 0;
-    for (String childId : children) packed += varintSize(state.stringIndex.get(childId));
-    return 1 + varintSize(packed) + packed; // tag + varint(packed) + packed bytes
-  }
-
   private static int referenceValueBodySize(int siResolveInfo, int siReferred) {
     return uint32FieldSize(siResolveInfo) + uint32FieldSize(siReferred);
   }
 
-  private static int referenceBodySize(
-      int mpiIndex, List<SerializedReferenceValue.Entry> entries, SerializeState state) {
-    int size = uint32FieldSize(mpiIndex);
-    for (SerializedReferenceValue.Entry entry : entries) {
-      int siReferred =
-          entry.getReference() != null
-              ? state.stringIndex.getOrDefault(entry.getReference(), 0)
-              : 0;
-      int siResolveInfo =
-          entry.getResolveInfo() != null
-              ? state.stringIndex.getOrDefault(entry.getResolveInfo(), 0)
-              : 0;
-      int rvBody = referenceValueBodySize(siResolveInfo, siReferred);
-      size += 1 + varintSize(rvBody) + rvBody;
-    }
-    return size;
-  }
-
-  private static int nodeBodySize(
-      SerializedClassifierInstance n, SerializeState state, boolean serializeEmptyFeatures) {
-    int size = 0;
-
-    // field 1: si_id
-    int siId = n.getID() != null ? state.stringIndex.getOrDefault(n.getID(), 0) : 0;
-    size += uint32FieldSize(siId);
-
-    // field 2: mpi_classifier
-    int mpiClassifier =
-        n.getClassifier() != null ? state.metaPointerIndex.getOrDefault(n.getClassifier(), 0) : 0;
-    size += uint32FieldSize(mpiClassifier);
-
-    // field 3: properties
-    for (SerializedPropertyValue p : n.getProperties()) {
-      String value = p.getValue();
-      if (serializeEmptyFeatures || value != null) {
-        int mpiIndex =
-            p.getMetaPointer() != null
-                ? state.metaPointerIndex.getOrDefault(p.getMetaPointer(), 0)
-                : 0;
-        int siValue = value != null ? state.stringIndex.getOrDefault(value, 0) : 0;
-        int bodySize = propertyBodySize(mpiIndex, siValue);
-        size += 1 + varintSize(bodySize) + bodySize;
-      }
-    }
-
-    // field 4: containments
-    for (SerializedContainmentValue c : n.getContainments()) {
-      List<String> children = c.getChildrenIds();
-      if (serializeEmptyFeatures || !children.isEmpty()) {
-        int mpiIndex =
-            c.getMetaPointer() != null
-                ? state.metaPointerIndex.getOrDefault(c.getMetaPointer(), 0)
-                : 0;
-        int bodySize = uint32FieldSize(mpiIndex) + packedChildrenSize(children, state);
-        size += 1 + varintSize(bodySize) + bodySize;
-      }
-    }
-
-    // field 5: references
-    for (SerializedReferenceValue r : n.getReferences()) {
-      List<SerializedReferenceValue.Entry> entries = r.getValue();
-      if (serializeEmptyFeatures || !entries.isEmpty()) {
-        int mpiIndex =
-            r.getMetaPointer() != null
-                ? state.metaPointerIndex.getOrDefault(r.getMetaPointer(), 0)
-                : 0;
-        int bodySize = referenceBodySize(mpiIndex, entries, state);
-        size += 1 + varintSize(bodySize) + bodySize;
-      }
-    }
-
-    // field 6: si_annotations (packed)
-    List<String> annotations = n.getAnnotations();
-    if (!annotations.isEmpty()) {
-      int packed = 0;
-      for (String annId : annotations)
-        packed += varintSize(state.stringIndex.getOrDefault(annId, 0));
-      size += 1 + varintSize(packed) + packed;
-    }
-
-    // field 7: si_parent
-    int siParent =
-        n.getParentNodeID() != null ? state.stringIndex.getOrDefault(n.getParentNodeID(), 0) : 0;
-    size += uint32FieldSize(siParent);
-
-    return size;
-  }
-
+  /** Computes the total chunk byte size from pre-computed node body sizes. */
   private static int computeChunkSize(
-      SerializationChunk chunk,
-      SerializeState state,
-      List<SerializedClassifierInstance> instances,
-      int[] nodeBodySizes,
-      boolean serializeEmptyFeatures) {
+      SerializationChunk chunk, SerializeState state, int[] nodeBodySizes) {
     int size = 0;
 
     // field 1: serialization_format_version
@@ -345,10 +279,8 @@ final class DirectProtoBufSerializer {
       size += 1 + varintSize(bodySize) + bodySize;
     }
 
-    // field 5: nodes — fill nodeBodySizes[] so writeChunk can reuse without re-computing
-    for (int i = 0, n = instances.size(); i < n; i++) {
-      int bodySize = nodeBodySize(instances.get(i), state, serializeEmptyFeatures);
-      nodeBodySizes[i] = bodySize;
+    // field 5: nodes — sizes already computed by visitAndComputeBodySize
+    for (int bodySize : nodeBodySizes) {
       size += 1 + varintSize(bodySize) + bodySize;
     }
 
@@ -401,7 +333,7 @@ final class DirectProtoBufSerializer {
       if (siVersion != 0) cos.writeUInt32(2, siVersion);
     }
 
-    // field 5: nodes — use pre-computed body sizes (no re-computation)
+    // field 5: nodes — use pre-computed body sizes
     for (int i = 0, n = instances.size(); i < n; i++) {
       cos.writeTag(5, WireFormat.WIRETYPE_LENGTH_DELIMITED);
       cos.writeUInt32NoTag(nodeBodySizes[i]);
@@ -434,7 +366,7 @@ final class DirectProtoBufSerializer {
                 ? state.metaPointerIndex.getOrDefault(p.getMetaPointer(), 0)
                 : 0;
         int siValue = value != null ? state.stringIndex.getOrDefault(value, 0) : 0;
-        int bodySize = propertyBodySize(mpiIndex, siValue);
+        int bodySize = uint32FieldSize(mpiIndex) + uint32FieldSize(siValue);
         cos.writeTag(3, WireFormat.WIRETYPE_LENGTH_DELIMITED);
         cos.writeUInt32NoTag(bodySize);
         if (mpiIndex != 0) cos.writeUInt32(1, mpiIndex);
@@ -442,7 +374,7 @@ final class DirectProtoBufSerializer {
       }
     }
 
-    // field 4: containments
+    // field 4: containments — compute 'packed' once for both the length prefix and the write loop
     for (SerializedContainmentValue c : n.getContainments()) {
       List<String> children = c.getChildrenIds();
       if (serializeEmptyFeatures || !children.isEmpty()) {
@@ -450,13 +382,14 @@ final class DirectProtoBufSerializer {
             c.getMetaPointer() != null
                 ? state.metaPointerIndex.getOrDefault(c.getMetaPointer(), 0)
                 : 0;
-        int bodySize = uint32FieldSize(mpiIndex) + packedChildrenSize(children, state);
+        int packed = 0;
+        for (String childId : children) packed += varintSize(state.stringIndex.get(childId));
+        int packedFieldSize = children.isEmpty() ? 0 : (1 + varintSize(packed) + packed);
+        int bodySize = uint32FieldSize(mpiIndex) + packedFieldSize;
         cos.writeTag(4, WireFormat.WIRETYPE_LENGTH_DELIMITED);
         cos.writeUInt32NoTag(bodySize);
         if (mpiIndex != 0) cos.writeUInt32(1, mpiIndex);
         if (!children.isEmpty()) {
-          int packed = 0;
-          for (String childId : children) packed += varintSize(state.stringIndex.get(childId));
           cos.writeTag(2, WireFormat.WIRETYPE_LENGTH_DELIMITED);
           cos.writeUInt32NoTag(packed);
           for (String childId : children) cos.writeUInt32NoTag(state.stringIndex.get(childId));
@@ -472,7 +405,19 @@ final class DirectProtoBufSerializer {
             r.getMetaPointer() != null
                 ? state.metaPointerIndex.getOrDefault(r.getMetaPointer(), 0)
                 : 0;
-        int refBodySize = referenceBodySize(mpiIndex, entries, state);
+        int refBodySize = uint32FieldSize(mpiIndex);
+        for (SerializedReferenceValue.Entry entry : entries) {
+          int siReferred =
+              entry.getReference() != null
+                  ? state.stringIndex.getOrDefault(entry.getReference(), 0)
+                  : 0;
+          int siResolveInfo =
+              entry.getResolveInfo() != null
+                  ? state.stringIndex.getOrDefault(entry.getResolveInfo(), 0)
+                  : 0;
+          int rvBody = referenceValueBodySize(siResolveInfo, siReferred);
+          refBodySize += 1 + varintSize(rvBody) + rvBody;
+        }
         cos.writeTag(5, WireFormat.WIRETYPE_LENGTH_DELIMITED);
         cos.writeUInt32NoTag(refBodySize);
         if (mpiIndex != 0) cos.writeUInt32(1, mpiIndex);

--- a/core/src/main/java/io/lionweb/serialization/DirectProtoBufSerializer.java
+++ b/core/src/main/java/io/lionweb/serialization/DirectProtoBufSerializer.java
@@ -1,0 +1,514 @@
+package io.lionweb.serialization;
+
+import com.google.protobuf.CodedOutputStream;
+import com.google.protobuf.WireFormat;
+import io.lionweb.serialization.data.*;
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * Serializes a {@link SerializationChunk} directly to the protobuf binary format without creating
+ * intermediate protobuf message objects (PBChunk, PBNode, etc.).
+ *
+ * <p>The two-pass strategy:
+ *
+ * <ol>
+ *   <li>Visit every node to populate the interned string / language / meta-pointer index tables.
+ *   <li>Compute the exact serialized byte count bottom-up (no intermediate byte arrays).
+ *   <li>Allocate a single {@code byte[]} and write all fields in one shot via {@link
+ *       CodedOutputStream}.
+ * </ol>
+ *
+ * <p>The output is byte-compatible with the standard protobuf serialization of a PBChunk message.
+ */
+final class DirectProtoBufSerializer {
+
+  private DirectProtoBufSerializer() {}
+
+  // ---- Public entry point ----
+
+  /**
+   * Serialize a {@link SerializationChunk} directly to protobuf bytes.
+   *
+   * @param chunk the chunk to serialize
+   * @param serializeEmptyFeatures when {@code false}, properties with null values and
+   *     containments/references with empty value lists are omitted
+   * @return the protobuf-encoded bytes
+   */
+  static byte[] serialize(SerializationChunk chunk, boolean serializeEmptyFeatures) {
+    SerializeState state = buildIndexTables(chunk, serializeEmptyFeatures);
+    List<SerializedClassifierInstance> instances = chunk.getClassifierInstances();
+
+    // Pre-compute every node body size once; reused in both computeChunkSize and writeChunk
+    // to avoid visiting each node twice.
+    int[] nodeBodySizes = new int[instances.size()];
+    int totalSize =
+        computeChunkSize(chunk, state, instances, nodeBodySizes, serializeEmptyFeatures);
+
+    byte[] result = new byte[totalSize];
+    CodedOutputStream cos = CodedOutputStream.newInstance(result);
+    try {
+      writeChunk(cos, chunk, state, instances, nodeBodySizes, serializeEmptyFeatures);
+    } catch (IOException e) {
+      throw new IllegalStateException("Unexpected IOException writing to byte array", e);
+    }
+    return result;
+  }
+
+  // ---- Index tables ----
+
+  /** Mutable state built during Phase 1 (visiting nodes). */
+  static final class SerializeState {
+    final List<String> strings = new ArrayList<>();
+    final Map<String, Integer> stringIndex = new HashMap<>();
+    final List<LanguageVersion> languages = new ArrayList<>();
+    final Map<LanguageVersion, Integer> languageIndex = new HashMap<>();
+    final List<MetaPointer> metaPointers = new ArrayList<>();
+    final Map<MetaPointer, Integer> metaPointerIndex = new HashMap<>();
+
+    SerializeState() {
+      strings.add(null);
+      stringIndex.put(null, 0);
+      languages.add(null);
+      languageIndex.put(null, 0);
+    }
+
+    int stringIndexer(String s) {
+      if (s == null) return 0;
+      Integer idx = stringIndex.get(s);
+      if (idx != null) return idx;
+      int index = strings.size();
+      strings.add(s);
+      stringIndex.put(s, index);
+      return index;
+    }
+
+    int languageIndexer(LanguageVersion lv) {
+      if (lv == null) return 0;
+      Integer idx = languageIndex.get(lv);
+      if (idx != null) return idx;
+      stringIndexer(lv.getKey());
+      stringIndexer(lv.getVersion());
+      int index = languages.size();
+      languages.add(lv);
+      languageIndex.put(lv, index);
+      return index;
+    }
+
+    int metaPointerIndexer(MetaPointer mp) {
+      if (mp == null) return 0;
+      Integer idx = metaPointerIndex.get(mp);
+      if (idx != null) return idx;
+      languageIndexer(mp.getLanguageVersion());
+      stringIndexer(mp.getKey());
+      int index = metaPointers.size();
+      metaPointers.add(mp);
+      metaPointerIndex.put(mp, index);
+      return index;
+    }
+  }
+
+  private static SerializeState buildIndexTables(
+      SerializationChunk chunk, boolean serializeEmptyFeatures) {
+    SerializeState state = new SerializeState();
+    for (SerializedClassifierInstance instance : chunk.getClassifierInstances()) {
+      visitNode(state, instance, serializeEmptyFeatures);
+    }
+    return state;
+  }
+
+  private static void visitNode(
+      SerializeState state, SerializedClassifierInstance n, boolean serializeEmptyFeatures) {
+    if (n.getID() != null) state.stringIndexer(n.getID());
+    if (n.getParentNodeID() != null) state.stringIndexer(n.getParentNodeID());
+    if (n.getClassifier() != null) state.metaPointerIndexer(n.getClassifier());
+
+    for (SerializedPropertyValue p : n.getProperties()) {
+      String value = p.getValue();
+      if (serializeEmptyFeatures || value != null) {
+        // Match legacy SerializeHelper: value string is indexed BEFORE the meta-pointer
+        state.stringIndexer(value); // null-safe: returns 0 and adds nothing when null
+        if (p.getMetaPointer() != null) state.metaPointerIndexer(p.getMetaPointer());
+      }
+    }
+
+    for (SerializedContainmentValue c : n.getContainments()) {
+      List<String> children = c.getChildrenIds();
+      if (serializeEmptyFeatures || !children.isEmpty()) {
+        if (c.getMetaPointer() != null) state.metaPointerIndexer(c.getMetaPointer());
+        for (String childId : children) state.stringIndexer(childId);
+      }
+    }
+
+    for (SerializedReferenceValue r : n.getReferences()) {
+      List<SerializedReferenceValue.Entry> entries = r.getValue();
+      if (serializeEmptyFeatures || !entries.isEmpty()) {
+        if (r.getMetaPointer() != null) state.metaPointerIndexer(r.getMetaPointer());
+        for (SerializedReferenceValue.Entry entry : entries) {
+          // Match legacy: referred indexed before resolveInfo
+          if (entry.getReference() != null) state.stringIndexer(entry.getReference());
+          if (entry.getResolveInfo() != null) state.stringIndexer(entry.getResolveInfo());
+        }
+      }
+    }
+
+    for (String annId : n.getAnnotations()) {
+      if (annId != null) state.stringIndexer(annId);
+    }
+  }
+
+  // ---- Size computation (Phase 2) ----
+
+  /** UTF-8 byte count for {@code s} without allocating a byte array. */
+  static int utf8ByteCount(String s) {
+    int count = 0;
+    for (int i = 0, len = s.length(); i < len; i++) {
+      char c = s.charAt(i);
+      if (c < 0x80) {
+        count += 1;
+      } else if (c < 0x800) {
+        count += 2;
+      } else if (Character.isHighSurrogate(c)) {
+        count += 4; // surrogate pair → 4 UTF-8 bytes
+        i++; // consume low surrogate
+      } else {
+        count += 3;
+      }
+    }
+    return count;
+  }
+
+  /** Varint encoding size of an unsigned 32-bit value. */
+  private static int varintSize(int v) {
+    return CodedOutputStream.computeUInt32SizeNoTag(v);
+  }
+
+  /**
+   * Wire size of a uint32 field (tag=1 byte + varint). Returns 0 when {@code value==0} because
+   * proto3 singular fields at their default value are not emitted.
+   */
+  private static int uint32FieldSize(int value) {
+    return value == 0 ? 0 : 1 + varintSize(value);
+  }
+
+  /** Wire size of a string LEN field: tag(1) + varint(utf8Len) + utf8Len. */
+  private static int stringFieldSize(String s) {
+    int utf8Len = utf8ByteCount(s);
+    return 1 + varintSize(utf8Len) + utf8Len;
+  }
+
+  private static int metaPointerBodySize(SerializeState state, MetaPointer mp) {
+    int liLanguage = state.languageIndex.getOrDefault(mp.getLanguageVersion(), 0);
+    int siKey = mp.getKey() != null ? state.stringIndex.getOrDefault(mp.getKey(), 0) : 0;
+    return uint32FieldSize(liLanguage) + uint32FieldSize(siKey);
+  }
+
+  private static int languageBodySize(SerializeState state, LanguageVersion lv) {
+    int siKey = lv.getKey() != null ? state.stringIndex.getOrDefault(lv.getKey(), 0) : 0;
+    int siVersion =
+        lv.getVersion() != null ? state.stringIndex.getOrDefault(lv.getVersion(), 0) : 0;
+    return uint32FieldSize(siKey) + uint32FieldSize(siVersion);
+  }
+
+  private static int propertyBodySize(int mpiIndex, int siValue) {
+    return uint32FieldSize(mpiIndex) + uint32FieldSize(siValue);
+  }
+
+  private static int packedChildrenSize(List<String> children, SerializeState state) {
+    if (children.isEmpty()) return 0;
+    int packed = 0;
+    for (String childId : children) packed += varintSize(state.stringIndex.get(childId));
+    return 1 + varintSize(packed) + packed; // tag + varint(packed) + packed bytes
+  }
+
+  private static int referenceValueBodySize(int siResolveInfo, int siReferred) {
+    return uint32FieldSize(siResolveInfo) + uint32FieldSize(siReferred);
+  }
+
+  private static int referenceBodySize(
+      int mpiIndex, List<SerializedReferenceValue.Entry> entries, SerializeState state) {
+    int size = uint32FieldSize(mpiIndex);
+    for (SerializedReferenceValue.Entry entry : entries) {
+      int siReferred =
+          entry.getReference() != null
+              ? state.stringIndex.getOrDefault(entry.getReference(), 0)
+              : 0;
+      int siResolveInfo =
+          entry.getResolveInfo() != null
+              ? state.stringIndex.getOrDefault(entry.getResolveInfo(), 0)
+              : 0;
+      int rvBody = referenceValueBodySize(siResolveInfo, siReferred);
+      size += 1 + varintSize(rvBody) + rvBody;
+    }
+    return size;
+  }
+
+  private static int nodeBodySize(
+      SerializedClassifierInstance n, SerializeState state, boolean serializeEmptyFeatures) {
+    int size = 0;
+
+    // field 1: si_id
+    int siId = n.getID() != null ? state.stringIndex.getOrDefault(n.getID(), 0) : 0;
+    size += uint32FieldSize(siId);
+
+    // field 2: mpi_classifier
+    int mpiClassifier =
+        n.getClassifier() != null ? state.metaPointerIndex.getOrDefault(n.getClassifier(), 0) : 0;
+    size += uint32FieldSize(mpiClassifier);
+
+    // field 3: properties
+    for (SerializedPropertyValue p : n.getProperties()) {
+      String value = p.getValue();
+      if (serializeEmptyFeatures || value != null) {
+        int mpiIndex =
+            p.getMetaPointer() != null
+                ? state.metaPointerIndex.getOrDefault(p.getMetaPointer(), 0)
+                : 0;
+        int siValue = value != null ? state.stringIndex.getOrDefault(value, 0) : 0;
+        int bodySize = propertyBodySize(mpiIndex, siValue);
+        size += 1 + varintSize(bodySize) + bodySize;
+      }
+    }
+
+    // field 4: containments
+    for (SerializedContainmentValue c : n.getContainments()) {
+      List<String> children = c.getChildrenIds();
+      if (serializeEmptyFeatures || !children.isEmpty()) {
+        int mpiIndex =
+            c.getMetaPointer() != null
+                ? state.metaPointerIndex.getOrDefault(c.getMetaPointer(), 0)
+                : 0;
+        int bodySize = uint32FieldSize(mpiIndex) + packedChildrenSize(children, state);
+        size += 1 + varintSize(bodySize) + bodySize;
+      }
+    }
+
+    // field 5: references
+    for (SerializedReferenceValue r : n.getReferences()) {
+      List<SerializedReferenceValue.Entry> entries = r.getValue();
+      if (serializeEmptyFeatures || !entries.isEmpty()) {
+        int mpiIndex =
+            r.getMetaPointer() != null
+                ? state.metaPointerIndex.getOrDefault(r.getMetaPointer(), 0)
+                : 0;
+        int bodySize = referenceBodySize(mpiIndex, entries, state);
+        size += 1 + varintSize(bodySize) + bodySize;
+      }
+    }
+
+    // field 6: si_annotations (packed)
+    List<String> annotations = n.getAnnotations();
+    if (!annotations.isEmpty()) {
+      int packed = 0;
+      for (String annId : annotations)
+        packed += varintSize(state.stringIndex.getOrDefault(annId, 0));
+      size += 1 + varintSize(packed) + packed;
+    }
+
+    // field 7: si_parent
+    int siParent =
+        n.getParentNodeID() != null ? state.stringIndex.getOrDefault(n.getParentNodeID(), 0) : 0;
+    size += uint32FieldSize(siParent);
+
+    return size;
+  }
+
+  private static int computeChunkSize(
+      SerializationChunk chunk,
+      SerializeState state,
+      List<SerializedClassifierInstance> instances,
+      int[] nodeBodySizes,
+      boolean serializeEmptyFeatures) {
+    int size = 0;
+
+    // field 1: serialization_format_version
+    String version = chunk.getSerializationFormatVersion();
+    if (version != null && !version.isEmpty()) {
+      size += stringFieldSize(version);
+    }
+
+    // field 2: interned_strings (index 0 = null, skip it)
+    for (int i = 1, n = state.strings.size(); i < n; i++) {
+      size += stringFieldSize(state.strings.get(i));
+    }
+
+    // field 3: interned_meta_pointers
+    for (MetaPointer mp : state.metaPointers) {
+      int bodySize = metaPointerBodySize(state, mp);
+      size += 1 + varintSize(bodySize) + bodySize;
+    }
+
+    // field 4: interned_languages (index 0 = null, skip it)
+    for (int i = 1, n = state.languages.size(); i < n; i++) {
+      LanguageVersion lv = state.languages.get(i);
+      int bodySize = languageBodySize(state, lv);
+      size += 1 + varintSize(bodySize) + bodySize;
+    }
+
+    // field 5: nodes — fill nodeBodySizes[] so writeChunk can reuse without re-computing
+    for (int i = 0, n = instances.size(); i < n; i++) {
+      int bodySize = nodeBodySize(instances.get(i), state, serializeEmptyFeatures);
+      nodeBodySizes[i] = bodySize;
+      size += 1 + varintSize(bodySize) + bodySize;
+    }
+
+    return size;
+  }
+
+  // ---- Write phase (Phase 3) ----
+
+  private static void writeChunk(
+      CodedOutputStream cos,
+      SerializationChunk chunk,
+      SerializeState state,
+      List<SerializedClassifierInstance> instances,
+      int[] nodeBodySizes,
+      boolean serializeEmptyFeatures)
+      throws IOException {
+
+    // field 1: serialization_format_version
+    String version = chunk.getSerializationFormatVersion();
+    if (version != null && !version.isEmpty()) {
+      cos.writeString(1, version);
+    }
+
+    // field 2: interned_strings
+    for (int i = 1, n = state.strings.size(); i < n; i++) {
+      cos.writeString(2, state.strings.get(i));
+    }
+
+    // field 3: interned_meta_pointers
+    for (MetaPointer mp : state.metaPointers) {
+      int bodySize = metaPointerBodySize(state, mp);
+      cos.writeTag(3, WireFormat.WIRETYPE_LENGTH_DELIMITED);
+      cos.writeUInt32NoTag(bodySize);
+      int liLanguage = state.languageIndex.getOrDefault(mp.getLanguageVersion(), 0);
+      int siKey = mp.getKey() != null ? state.stringIndex.getOrDefault(mp.getKey(), 0) : 0;
+      if (liLanguage != 0) cos.writeUInt32(1, liLanguage);
+      if (siKey != 0) cos.writeUInt32(2, siKey);
+    }
+
+    // field 4: interned_languages
+    for (int i = 1, n = state.languages.size(); i < n; i++) {
+      LanguageVersion lv = state.languages.get(i);
+      int bodySize = languageBodySize(state, lv);
+      cos.writeTag(4, WireFormat.WIRETYPE_LENGTH_DELIMITED);
+      cos.writeUInt32NoTag(bodySize);
+      int siKey = lv.getKey() != null ? state.stringIndex.getOrDefault(lv.getKey(), 0) : 0;
+      int siVersion =
+          lv.getVersion() != null ? state.stringIndex.getOrDefault(lv.getVersion(), 0) : 0;
+      if (siKey != 0) cos.writeUInt32(1, siKey);
+      if (siVersion != 0) cos.writeUInt32(2, siVersion);
+    }
+
+    // field 5: nodes — use pre-computed body sizes (no re-computation)
+    for (int i = 0, n = instances.size(); i < n; i++) {
+      cos.writeTag(5, WireFormat.WIRETYPE_LENGTH_DELIMITED);
+      cos.writeUInt32NoTag(nodeBodySizes[i]);
+      writeNodeBody(cos, instances.get(i), state, serializeEmptyFeatures);
+    }
+  }
+
+  private static void writeNodeBody(
+      CodedOutputStream cos,
+      SerializedClassifierInstance n,
+      SerializeState state,
+      boolean serializeEmptyFeatures)
+      throws IOException {
+
+    // field 1: si_id
+    int siId = n.getID() != null ? state.stringIndex.getOrDefault(n.getID(), 0) : 0;
+    if (siId != 0) cos.writeUInt32(1, siId);
+
+    // field 2: mpi_classifier
+    int mpiClassifier =
+        n.getClassifier() != null ? state.metaPointerIndex.getOrDefault(n.getClassifier(), 0) : 0;
+    if (mpiClassifier != 0) cos.writeUInt32(2, mpiClassifier);
+
+    // field 3: properties
+    for (SerializedPropertyValue p : n.getProperties()) {
+      String value = p.getValue();
+      if (serializeEmptyFeatures || value != null) {
+        int mpiIndex =
+            p.getMetaPointer() != null
+                ? state.metaPointerIndex.getOrDefault(p.getMetaPointer(), 0)
+                : 0;
+        int siValue = value != null ? state.stringIndex.getOrDefault(value, 0) : 0;
+        int bodySize = propertyBodySize(mpiIndex, siValue);
+        cos.writeTag(3, WireFormat.WIRETYPE_LENGTH_DELIMITED);
+        cos.writeUInt32NoTag(bodySize);
+        if (mpiIndex != 0) cos.writeUInt32(1, mpiIndex);
+        if (siValue != 0) cos.writeUInt32(2, siValue);
+      }
+    }
+
+    // field 4: containments
+    for (SerializedContainmentValue c : n.getContainments()) {
+      List<String> children = c.getChildrenIds();
+      if (serializeEmptyFeatures || !children.isEmpty()) {
+        int mpiIndex =
+            c.getMetaPointer() != null
+                ? state.metaPointerIndex.getOrDefault(c.getMetaPointer(), 0)
+                : 0;
+        int bodySize = uint32FieldSize(mpiIndex) + packedChildrenSize(children, state);
+        cos.writeTag(4, WireFormat.WIRETYPE_LENGTH_DELIMITED);
+        cos.writeUInt32NoTag(bodySize);
+        if (mpiIndex != 0) cos.writeUInt32(1, mpiIndex);
+        if (!children.isEmpty()) {
+          int packed = 0;
+          for (String childId : children) packed += varintSize(state.stringIndex.get(childId));
+          cos.writeTag(2, WireFormat.WIRETYPE_LENGTH_DELIMITED);
+          cos.writeUInt32NoTag(packed);
+          for (String childId : children) cos.writeUInt32NoTag(state.stringIndex.get(childId));
+        }
+      }
+    }
+
+    // field 5: references
+    for (SerializedReferenceValue r : n.getReferences()) {
+      List<SerializedReferenceValue.Entry> entries = r.getValue();
+      if (serializeEmptyFeatures || !entries.isEmpty()) {
+        int mpiIndex =
+            r.getMetaPointer() != null
+                ? state.metaPointerIndex.getOrDefault(r.getMetaPointer(), 0)
+                : 0;
+        int refBodySize = referenceBodySize(mpiIndex, entries, state);
+        cos.writeTag(5, WireFormat.WIRETYPE_LENGTH_DELIMITED);
+        cos.writeUInt32NoTag(refBodySize);
+        if (mpiIndex != 0) cos.writeUInt32(1, mpiIndex);
+        for (SerializedReferenceValue.Entry entry : entries) {
+          int siReferred =
+              entry.getReference() != null
+                  ? state.stringIndex.getOrDefault(entry.getReference(), 0)
+                  : 0;
+          int siResolveInfo =
+              entry.getResolveInfo() != null
+                  ? state.stringIndex.getOrDefault(entry.getResolveInfo(), 0)
+                  : 0;
+          int rvBody = referenceValueBodySize(siResolveInfo, siReferred);
+          cos.writeTag(2, WireFormat.WIRETYPE_LENGTH_DELIMITED);
+          cos.writeUInt32NoTag(rvBody);
+          if (siResolveInfo != 0) cos.writeUInt32(1, siResolveInfo);
+          if (siReferred != 0) cos.writeUInt32(2, siReferred);
+        }
+      }
+    }
+
+    // field 6: si_annotations (packed repeated uint32)
+    List<String> annotations = n.getAnnotations();
+    if (!annotations.isEmpty()) {
+      int packed = 0;
+      for (String annId : annotations)
+        packed += varintSize(state.stringIndex.getOrDefault(annId, 0));
+      cos.writeTag(6, WireFormat.WIRETYPE_LENGTH_DELIMITED);
+      cos.writeUInt32NoTag(packed);
+      for (String annId : annotations)
+        cos.writeUInt32NoTag(state.stringIndex.getOrDefault(annId, 0));
+    }
+
+    // field 7: si_parent
+    int siParent =
+        n.getParentNodeID() != null ? state.stringIndex.getOrDefault(n.getParentNodeID(), 0) : 0;
+    if (siParent != 0) cos.writeUInt32(7, siParent);
+  }
+}

--- a/core/src/main/java/io/lionweb/serialization/DirectProtoBufSerializer.java
+++ b/core/src/main/java/io/lionweb/serialization/DirectProtoBufSerializer.java
@@ -334,7 +334,8 @@ final class DirectProtoBufSerializer {
       int siId = n.getID() != null ? state.stringIndexer(n.getID()) : 0;
       nodeSiId[ni] = siId;
 
-      // field 7: si_parent — indexed here (between id and classifier) to match legacy table ordering
+      // field 7: si_parent — indexed here (between id and classifier) to match legacy table
+      // ordering
       int siParent = n.getParentNodeID() != null ? state.stringIndexer(n.getParentNodeID()) : 0;
       nodeSiParent[ni] = siParent;
 
@@ -410,8 +411,7 @@ final class DirectProtoBufSerializer {
           for (int k = 0; k < nEntries; k++) {
             SerializedReferenceValue.Entry entry = entries.get(k);
             // Match legacy: referred indexed before resolveInfo
-            int sr =
-                entry.getReference() != null ? state.stringIndexer(entry.getReference()) : 0;
+            int sr = entry.getReference() != null ? state.stringIndexer(entry.getReference()) : 0;
             int sri =
                 entry.getResolveInfo() != null ? state.stringIndexer(entry.getResolveInfo()) : 0;
             int rvBody = uint32FieldSize(sri) + uint32FieldSize(sr);

--- a/core/src/main/java/io/lionweb/serialization/DirectProtoBufSerializer.java
+++ b/core/src/main/java/io/lionweb/serialization/DirectProtoBufSerializer.java
@@ -10,65 +10,43 @@ import java.util.*;
  * Serializes a {@link SerializationChunk} directly to the protobuf binary format without creating
  * intermediate protobuf message objects (PBChunk, PBNode, etc.).
  *
- * <p>The two-pass strategy:
+ * <p>Strategy:
  *
  * <ol>
- *   <li>Visit every node to populate the interned string / language / meta-pointer index tables
- *       <em>and</em> compute each node's serialized body size in the same traversal.
- *   <li>Compute the exact total byte count from the index tables plus the pre-computed node sizes.
- *   <li>Allocate a single {@code byte[]} and write all fields in one shot via {@link
- *       CodedOutputStream}.
+ *   <li>Traverse all nodes once to populate string / language / meta-pointer intern tables and
+ *       build a {@link SerializationPlan} containing every integer index and pre-computed body size
+ *       needed for writing.
+ *   <li>Build a {@link CachedTables} containing UTF-8 lengths, meta-pointer body sizes, and
+ *       language body sizes derived from the now-complete intern tables.
+ *   <li>Compute the exact total byte count without touching domain objects.
+ *   <li>Allocate one {@code byte[]} and write from the plan — zero HashMap lookups, zero domain-
+ *       object traversal.
  * </ol>
  *
- * <p>The output is byte-compatible with the standard protobuf serialization of a PBChunk message.
+ * <p>The output is byte-for-byte identical to standard protobuf serialization of a PBChunk message.
  */
 final class DirectProtoBufSerializer {
 
   private DirectProtoBufSerializer() {}
 
-  // ---- Public entry point ----
+  // ---- Inner types ----
 
-  /**
-   * Serialize a {@link SerializationChunk} directly to protobuf bytes.
-   *
-   * @param chunk the chunk to serialize
-   * @param serializeEmptyFeatures when {@code false}, properties with null values and
-   *     containments/references with empty value lists are omitted
-   * @return the protobuf-encoded bytes
-   */
-  static byte[] serialize(SerializationChunk chunk, boolean serializeEmptyFeatures) {
-    SerializeState state = new SerializeState();
-    List<SerializedClassifierInstance> instances = chunk.getClassifierInstances();
-
-    // Single pass: build index tables AND compute each node's body size simultaneously.
-    int[] nodeBodySizes = new int[instances.size()];
-    for (int i = 0; i < instances.size(); i++) {
-      nodeBodySizes[i] = visitAndComputeBodySize(state, instances.get(i), serializeEmptyFeatures);
-    }
-
-    int totalSize = computeChunkSize(chunk, state, nodeBodySizes);
-    byte[] result = new byte[totalSize];
-    CodedOutputStream cos = CodedOutputStream.newInstance(result);
-    try {
-      writeChunk(cos, chunk, state, instances, nodeBodySizes, serializeEmptyFeatures);
-    } catch (IOException e) {
-      throw new IllegalStateException("Unexpected IOException writing to byte array", e);
-    }
-    return result;
-  }
-
-  // ---- Index tables ----
-
-  /** Mutable state built during Phase 1 (visiting nodes). */
+  /** Mutable intern tables built during the first traversal. */
   static final class SerializeState {
-    final List<String> strings = new ArrayList<>();
-    final Map<String, Integer> stringIndex = new HashMap<>();
-    final List<LanguageVersion> languages = new ArrayList<>();
-    final Map<LanguageVersion, Integer> languageIndex = new HashMap<>();
-    final List<MetaPointer> metaPointers = new ArrayList<>();
-    final Map<MetaPointer, Integer> metaPointerIndex = new HashMap<>();
+    final List<String> strings;
+    final Map<String, Integer> stringIndex;
+    final List<LanguageVersion> languages;
+    final Map<LanguageVersion, Integer> languageIndex;
+    final List<MetaPointer> metaPointers;
+    final Map<MetaPointer, Integer> metaPointerIndex;
 
-    SerializeState() {
+    SerializeState(int estimatedStrings, int estimatedLanguages, int estimatedMetaPointers) {
+      strings = new ArrayList<>(estimatedStrings + 1);
+      stringIndex = new HashMap<>(hashCapacity(estimatedStrings + 1));
+      languages = new ArrayList<>(estimatedLanguages + 1);
+      languageIndex = new HashMap<>(hashCapacity(estimatedLanguages + 1));
+      metaPointers = new ArrayList<>(estimatedMetaPointers);
+      metaPointerIndex = new HashMap<>(hashCapacity(estimatedMetaPointers));
       strings.add(null);
       stringIndex.put(null, 0);
       languages.add(null);
@@ -111,89 +89,435 @@ final class DirectProtoBufSerializer {
   }
 
   /**
-   * Visits {@code n} to populate index tables AND returns the node's serialized body size in a
-   * single traversal, eliminating a separate size-computation pass.
-   *
-   * <p>Field indexing order matches the legacy {@code SerializeHelper.serializeNode} exactly so
-   * that string/language/meta-pointer table indices — and therefore the output bytes — are
-   * identical.
+   * Resolved integer indexes and pre-computed body sizes for a single node. Built once; used by
+   * both the size-computation phase and the write phase without any map lookups.
    */
-  private static int visitAndComputeBodySize(
+  static final class NodePlan {
+    int siId, mpiClassifier, siParent, bodySize;
+
+    // Properties: arrays of length propCount (null when propCount == 0)
+    int propCount;
+    int[] propMpi, propSiValue, propBodySize;
+
+    // Containments: arrays of length contCount (null when contCount == 0)
+    int contCount;
+    int[] contMpi, contBodySize, contPackedRawSize;
+    int[][] contChildIndexes; // [contCount][childCount per containment]
+
+    // References: arrays of length refCount (null when refCount == 0)
+    int refCount;
+    int[] refMpi, refBodySize;
+    int[][] refSiResolveInfo, refSiReferred, refEntryBodySize;
+
+    // Annotations (null when there are no annotations)
+    int[] annotationIndexes;
+    int annotPackedRawSize; // sum of varintSize(annotIdx) — used as the packed-field length prefix
+  }
+
+  /**
+   * Derived numeric arrays computed once from the completed intern tables. Eliminates HashMap
+   * lookups in both the size-computation and write phases for the chunk header fields.
+   */
+  static final class CachedTables {
+    // Parallel to state.strings: [i] = utf8ByteCount(strings[i]) for i >= 1
+    final int[] stringUtf8Lengths;
+
+    // Parallel to state.metaPointers (0-indexed)
+    final int[] mpBodySizes;
+    final int[] mpLiLanguage; // language index for each meta-pointer
+    final int[] mpSiKey;      // key string index for each meta-pointer
+
+    // Parallel to state.languages (1-indexed; [i] corresponds to languages[i+1])
+    final int[] langBodySizes;
+    final int[] langSiKey;
+    final int[] langSiVersion;
+
+    CachedTables(SerializeState state) {
+      int stringCount = state.strings.size() - 1;
+      stringUtf8Lengths = new int[stringCount + 1];
+      for (int i = 1; i <= stringCount; i++) {
+        stringUtf8Lengths[i] = utf8ByteCount(state.strings.get(i));
+      }
+
+      int mpCount = state.metaPointers.size();
+      mpBodySizes = new int[mpCount];
+      mpLiLanguage = new int[mpCount];
+      mpSiKey = new int[mpCount];
+      for (int i = 0; i < mpCount; i++) {
+        MetaPointer mp = state.metaPointers.get(i);
+        // At this point all entries are guaranteed to be in the maps; use get() not getOrDefault()
+        int li = mp.getLanguageVersion() != null
+            ? requireIndex(state.languageIndex, mp.getLanguageVersion(), "LanguageVersion") : 0;
+        int sk = mp.getKey() != null
+            ? requireIndex(state.stringIndex, mp.getKey(), "string") : 0;
+        mpLiLanguage[i] = li;
+        mpSiKey[i] = sk;
+        mpBodySizes[i] = uint32FieldSize(li) + uint32FieldSize(sk);
+      }
+
+      int langCount = state.languages.size() - 1;
+      langBodySizes = new int[langCount];
+      langSiKey = new int[langCount];
+      langSiVersion = new int[langCount];
+      for (int i = 0; i < langCount; i++) {
+        LanguageVersion lv = state.languages.get(i + 1);
+        int sk = lv.getKey() != null
+            ? requireIndex(state.stringIndex, lv.getKey(), "string") : 0;
+        int sv = lv.getVersion() != null
+            ? requireIndex(state.stringIndex, lv.getVersion(), "string") : 0;
+        langSiKey[i] = sk;
+        langSiVersion[i] = sv;
+        langBodySizes[i] = uint32FieldSize(sk) + uint32FieldSize(sv);
+      }
+    }
+
+    private static int requireIndex(Map<?, Integer> map, Object key, String kind) {
+      Integer idx = map.get(key);
+      if (idx == null) {
+        throw new IllegalStateException("Intern table missing " + kind + ": " + key);
+      }
+      return idx;
+    }
+  }
+
+  // ---- Public entry point ----
+
+  static byte[] serialize(SerializationChunk chunk, boolean serializeEmptyFeatures) {
+    List<SerializedClassifierInstance> instances = chunk.getClassifierInstances();
+    int nodeCount = instances.size();
+
+    // Heuristic pre-sizing to avoid resize overhead on typical models
+    int estimatedStrings = Math.max(16, nodeCount * 4);
+    int estimatedMetaPointers = Math.max(16, nodeCount / 2);
+
+    SerializeState state = new SerializeState(estimatedStrings, 8, estimatedMetaPointers);
+
+    // Single traversal: populate intern tables AND build per-node plans
+    NodePlan[] plans = new NodePlan[nodeCount];
+    for (int i = 0; i < nodeCount; i++) {
+      plans[i] = buildNodePlan(state, instances.get(i), serializeEmptyFeatures);
+    }
+
+    CachedTables cached = new CachedTables(state);
+    int totalSize = computeChunkSize(chunk, cached, plans);
+
+    byte[] result = new byte[totalSize];
+    CodedOutputStream cos = CodedOutputStream.newInstance(result);
+    try {
+      writeChunk(cos, chunk, state, cached, plans);
+    } catch (IOException e) {
+      throw new IllegalStateException("Unexpected IOException writing to byte array", e);
+    }
+    return result;
+  }
+
+  // ---- Plan building ----
+
+  private static NodePlan buildNodePlan(
       SerializeState state, SerializedClassifierInstance n, boolean serializeEmptyFeatures) {
-    int size = 0;
+    NodePlan plan = new NodePlan();
 
     // field 1: si_id
-    if (n.getID() != null) size += uint32FieldSize(state.stringIndexer(n.getID()));
+    plan.siId = n.getID() != null ? state.stringIndexer(n.getID()) : 0;
 
-    // field 7: si_parent — indexed here to match legacy ordering; size contributed below
-    int siParent = n.getParentNodeID() != null ? state.stringIndexer(n.getParentNodeID()) : 0;
+    // field 7: si_parent — indexed here (between id and classifier) to match legacy table ordering
+    plan.siParent = n.getParentNodeID() != null ? state.stringIndexer(n.getParentNodeID()) : 0;
 
     // field 2: mpi_classifier
-    if (n.getClassifier() != null)
-      size += uint32FieldSize(state.metaPointerIndexer(n.getClassifier()));
+    plan.mpiClassifier = n.getClassifier() != null ? state.metaPointerIndexer(n.getClassifier()) : 0;
+
+    int bodySize = uint32FieldSize(plan.siId) + uint32FieldSize(plan.mpiClassifier);
 
     // field 3: properties
-    for (SerializedPropertyValue p : n.getProperties()) {
-      String value = p.getValue();
-      if (serializeEmptyFeatures || value != null) {
-        // Match legacy SerializeHelper: value string indexed BEFORE meta-pointer
-        int siValue = state.stringIndexer(value);
-        int mpiIndex =
-            p.getMetaPointer() != null ? state.metaPointerIndexer(p.getMetaPointer()) : 0;
-        int bodySize = uint32FieldSize(mpiIndex) + uint32FieldSize(siValue);
-        size += 1 + varintSize(bodySize) + bodySize;
+    List<SerializedPropertyValue> propList = n.getProperties();
+    int propCount = 0;
+    for (SerializedPropertyValue p : propList) {
+      if (serializeEmptyFeatures || p.getValue() != null) propCount++;
+    }
+    plan.propCount = propCount;
+    if (propCount > 0) {
+      plan.propMpi = new int[propCount];
+      plan.propSiValue = new int[propCount];
+      plan.propBodySize = new int[propCount];
+      int pi = 0;
+      for (SerializedPropertyValue p : propList) {
+        String value = p.getValue();
+        if (serializeEmptyFeatures || value != null) {
+          // Match legacy SerializeHelper: value string indexed BEFORE meta-pointer
+          int siValue = state.stringIndexer(value);
+          int mpi = p.getMetaPointer() != null ? state.metaPointerIndexer(p.getMetaPointer()) : 0;
+          int pb = uint32FieldSize(mpi) + uint32FieldSize(siValue);
+          plan.propMpi[pi] = mpi;
+          plan.propSiValue[pi] = siValue;
+          plan.propBodySize[pi] = pb;
+          bodySize += 1 + varintSize(pb) + pb;
+          pi++;
+        }
       }
     }
 
     // field 4: containments
-    for (SerializedContainmentValue c : n.getContainments()) {
-      List<String> children = c.getChildrenIds();
-      if (serializeEmptyFeatures || !children.isEmpty()) {
-        int mpiIndex =
-            c.getMetaPointer() != null ? state.metaPointerIndexer(c.getMetaPointer()) : 0;
-        int packed = 0;
-        for (String childId : children) packed += varintSize(state.stringIndexer(childId));
-        int packedFieldSize = children.isEmpty() ? 0 : (1 + varintSize(packed) + packed);
-        int bodySize = uint32FieldSize(mpiIndex) + packedFieldSize;
-        size += 1 + varintSize(bodySize) + bodySize;
+    List<SerializedContainmentValue> contList = n.getContainments();
+    int contCount = 0;
+    for (SerializedContainmentValue c : contList) {
+      if (serializeEmptyFeatures || !c.getChildrenIds().isEmpty()) contCount++;
+    }
+    plan.contCount = contCount;
+    if (contCount > 0) {
+      plan.contMpi = new int[contCount];
+      plan.contBodySize = new int[contCount];
+      plan.contPackedRawSize = new int[contCount];
+      plan.contChildIndexes = new int[contCount][];
+      int ci = 0;
+      for (SerializedContainmentValue c : contList) {
+        List<String> children = c.getChildrenIds();
+        if (serializeEmptyFeatures || !children.isEmpty()) {
+          int mpi = c.getMetaPointer() != null ? state.metaPointerIndexer(c.getMetaPointer()) : 0;
+          int nChildren = children.size();
+          int[] childIdxs = new int[nChildren];
+          int packed = 0;
+          for (int k = 0; k < nChildren; k++) {
+            childIdxs[k] = state.stringIndexer(children.get(k));
+            packed += varintSize(childIdxs[k]);
+          }
+          int packedFieldSize = nChildren == 0 ? 0 : (1 + varintSize(packed) + packed);
+          int cb = uint32FieldSize(mpi) + packedFieldSize;
+          plan.contMpi[ci] = mpi;
+          plan.contBodySize[ci] = cb;
+          plan.contPackedRawSize[ci] = packed; // raw byte count of the packed content
+          plan.contChildIndexes[ci] = childIdxs;
+          bodySize += 1 + varintSize(cb) + cb;
+          ci++;
+        }
       }
     }
 
     // field 5: references
-    for (SerializedReferenceValue r : n.getReferences()) {
-      List<SerializedReferenceValue.Entry> entries = r.getValue();
-      if (serializeEmptyFeatures || !entries.isEmpty()) {
-        int mpiIndex =
-            r.getMetaPointer() != null ? state.metaPointerIndexer(r.getMetaPointer()) : 0;
-        int refBodySize = uint32FieldSize(mpiIndex);
-        for (SerializedReferenceValue.Entry entry : entries) {
-          // Match legacy: referred indexed before resolveInfo
-          int siReferred =
-              entry.getReference() != null ? state.stringIndexer(entry.getReference()) : 0;
-          int siResolveInfo =
-              entry.getResolveInfo() != null ? state.stringIndexer(entry.getResolveInfo()) : 0;
-          int rvBody = referenceValueBodySize(siResolveInfo, siReferred);
-          refBodySize += 1 + varintSize(rvBody) + rvBody;
+    List<SerializedReferenceValue> refList = n.getReferences();
+    int refCount = 0;
+    for (SerializedReferenceValue r : refList) {
+      if (serializeEmptyFeatures || !r.getValue().isEmpty()) refCount++;
+    }
+    plan.refCount = refCount;
+    if (refCount > 0) {
+      plan.refMpi = new int[refCount];
+      plan.refBodySize = new int[refCount];
+      plan.refSiResolveInfo = new int[refCount][];
+      plan.refSiReferred = new int[refCount][];
+      plan.refEntryBodySize = new int[refCount][];
+      int ri = 0;
+      for (SerializedReferenceValue r : refList) {
+        List<SerializedReferenceValue.Entry> entries = r.getValue();
+        if (serializeEmptyFeatures || !entries.isEmpty()) {
+          int mpi = r.getMetaPointer() != null ? state.metaPointerIndexer(r.getMetaPointer()) : 0;
+          int nEntries = entries.size();
+          int[] siResolveInfo = new int[nEntries];
+          int[] siReferred = new int[nEntries];
+          int[] entryBodies = new int[nEntries];
+          int refBody = uint32FieldSize(mpi);
+          for (int k = 0; k < nEntries; k++) {
+            SerializedReferenceValue.Entry entry = entries.get(k);
+            // Match legacy: referred indexed before resolveInfo
+            int sr = entry.getReference() != null ? state.stringIndexer(entry.getReference()) : 0;
+            int sri = entry.getResolveInfo() != null ? state.stringIndexer(entry.getResolveInfo()) : 0;
+            int rvBody = uint32FieldSize(sri) + uint32FieldSize(sr);
+            siResolveInfo[k] = sri;
+            siReferred[k] = sr;
+            entryBodies[k] = rvBody;
+            refBody += 1 + varintSize(rvBody) + rvBody;
+          }
+          plan.refMpi[ri] = mpi;
+          plan.refBodySize[ri] = refBody;
+          plan.refSiResolveInfo[ri] = siResolveInfo;
+          plan.refSiReferred[ri] = siReferred;
+          plan.refEntryBodySize[ri] = entryBodies;
+          bodySize += 1 + varintSize(refBody) + refBody;
+          ri++;
         }
-        size += 1 + varintSize(refBodySize) + refBodySize;
       }
     }
 
-    // field 6: si_annotations (packed)
+    // field 6: annotations (packed repeated uint32)
     List<String> annotations = n.getAnnotations();
     if (!annotations.isEmpty()) {
+      int nAnn = annotations.size();
+      int[] annIdxs = new int[nAnn];
       int packed = 0;
-      for (String annId : annotations) packed += varintSize(state.stringIndexer(annId));
-      size += 1 + varintSize(packed) + packed;
+      for (int k = 0; k < nAnn; k++) {
+        // null annotation IDs map to index 0 (preserved from legacy getOrDefault behavior)
+        annIdxs[k] = state.stringIndexer(annotations.get(k));
+        packed += varintSize(annIdxs[k]);
+      }
+      plan.annotationIndexes = annIdxs;
+      plan.annotPackedRawSize = packed;
+      bodySize += 1 + varintSize(packed) + packed;
     }
 
-    // field 7: si_parent size (index already computed above to preserve table-population order)
-    size += uint32FieldSize(siParent);
+    // field 7: si_parent size (index already set above for table-ordering purposes)
+    bodySize += uint32FieldSize(plan.siParent);
+
+    plan.bodySize = bodySize;
+    return plan;
+  }
+
+  // ---- Size computation ----
+
+  /** Computes the total serialized byte count from cached tables and plans — no domain objects. */
+  private static int computeChunkSize(
+      SerializationChunk chunk, CachedTables cached, NodePlan[] plans) {
+    int size = 0;
+
+    // field 1: serialization_format_version (not in the intern table; computed ad-hoc)
+    String version = chunk.getSerializationFormatVersion();
+    if (version != null && !version.isEmpty()) {
+      int utf8Len = utf8ByteCount(version);
+      size += 1 + varintSize(utf8Len) + utf8Len;
+    }
+
+    // field 2: interned_strings
+    for (int i = 1; i < cached.stringUtf8Lengths.length; i++) {
+      int utf8Len = cached.stringUtf8Lengths[i];
+      size += 1 + varintSize(utf8Len) + utf8Len;
+    }
+
+    // field 3: interned_meta_pointers
+    for (int bodySize : cached.mpBodySizes) {
+      size += 1 + varintSize(bodySize) + bodySize;
+    }
+
+    // field 4: interned_languages
+    for (int bodySize : cached.langBodySizes) {
+      size += 1 + varintSize(bodySize) + bodySize;
+    }
+
+    // field 5: nodes
+    for (NodePlan plan : plans) {
+      size += 1 + varintSize(plan.bodySize) + plan.bodySize;
+    }
 
     return size;
   }
 
-  // ---- Size helpers ----
+  // ---- Write phase ----
+
+  /**
+   * Writes the entire chunk. No HashMap lookups; no domain-object traversal. All data comes from
+   * {@code cached} arrays and {@code plans}.
+   */
+  private static void writeChunk(
+      CodedOutputStream cos,
+      SerializationChunk chunk,
+      SerializeState state,
+      CachedTables cached,
+      NodePlan[] plans)
+      throws IOException {
+
+    // field 1: serialization_format_version
+    String version = chunk.getSerializationFormatVersion();
+    if (version != null && !version.isEmpty()) {
+      cos.writeString(1, version);
+    }
+
+    // field 2: interned_strings
+    List<String> strings = state.strings;
+    for (int i = 1; i < strings.size(); i++) {
+      cos.writeString(2, strings.get(i));
+    }
+
+    // field 3: interned_meta_pointers — use cached integer arrays, no map lookups
+    int mpCount = cached.mpBodySizes.length;
+    for (int i = 0; i < mpCount; i++) {
+      cos.writeTag(3, WireFormat.WIRETYPE_LENGTH_DELIMITED);
+      cos.writeUInt32NoTag(cached.mpBodySizes[i]);
+      int li = cached.mpLiLanguage[i];
+      int sk = cached.mpSiKey[i];
+      if (li != 0) cos.writeUInt32(1, li);
+      if (sk != 0) cos.writeUInt32(2, sk);
+    }
+
+    // field 4: interned_languages — use cached integer arrays, no map lookups
+    int langCount = cached.langBodySizes.length;
+    for (int i = 0; i < langCount; i++) {
+      cos.writeTag(4, WireFormat.WIRETYPE_LENGTH_DELIMITED);
+      cos.writeUInt32NoTag(cached.langBodySizes[i]);
+      int sk = cached.langSiKey[i];
+      int sv = cached.langSiVersion[i];
+      if (sk != 0) cos.writeUInt32(1, sk);
+      if (sv != 0) cos.writeUInt32(2, sv);
+    }
+
+    // field 5: nodes — written entirely from plans, zero map lookups
+    for (NodePlan plan : plans) {
+      cos.writeTag(5, WireFormat.WIRETYPE_LENGTH_DELIMITED);
+      cos.writeUInt32NoTag(plan.bodySize);
+      writeNodeBody(cos, plan);
+    }
+  }
+
+  private static void writeNodeBody(CodedOutputStream cos, NodePlan plan) throws IOException {
+    // field 1: si_id
+    if (plan.siId != 0) cos.writeUInt32(1, plan.siId);
+
+    // field 2: mpi_classifier
+    if (plan.mpiClassifier != 0) cos.writeUInt32(2, plan.mpiClassifier);
+
+    // field 3: properties
+    for (int i = 0; i < plan.propCount; i++) {
+      int bodySize = plan.propBodySize[i];
+      cos.writeTag(3, WireFormat.WIRETYPE_LENGTH_DELIMITED);
+      cos.writeUInt32NoTag(bodySize);
+      int mpi = plan.propMpi[i];
+      int sv = plan.propSiValue[i];
+      if (mpi != 0) cos.writeUInt32(1, mpi);
+      if (sv != 0) cos.writeUInt32(2, sv);
+    }
+
+    // field 4: containments
+    for (int i = 0; i < plan.contCount; i++) {
+      cos.writeTag(4, WireFormat.WIRETYPE_LENGTH_DELIMITED);
+      cos.writeUInt32NoTag(plan.contBodySize[i]);
+      int mpi = plan.contMpi[i];
+      if (mpi != 0) cos.writeUInt32(1, mpi);
+      int[] childIdxs = plan.contChildIndexes[i];
+      if (childIdxs.length > 0) {
+        cos.writeTag(2, WireFormat.WIRETYPE_LENGTH_DELIMITED);
+        cos.writeUInt32NoTag(plan.contPackedRawSize[i]);
+        for (int childIdx : childIdxs) cos.writeUInt32NoTag(childIdx);
+      }
+    }
+
+    // field 5: references
+    for (int i = 0; i < plan.refCount; i++) {
+      cos.writeTag(5, WireFormat.WIRETYPE_LENGTH_DELIMITED);
+      cos.writeUInt32NoTag(plan.refBodySize[i]);
+      int mpi = plan.refMpi[i];
+      if (mpi != 0) cos.writeUInt32(1, mpi);
+      int[] siResolveInfo = plan.refSiResolveInfo[i];
+      int[] siReferred = plan.refSiReferred[i];
+      int[] entryBodies = plan.refEntryBodySize[i];
+      for (int k = 0; k < siReferred.length; k++) {
+        int rvBody = entryBodies[k];
+        cos.writeTag(2, WireFormat.WIRETYPE_LENGTH_DELIMITED);
+        cos.writeUInt32NoTag(rvBody);
+        int sri = siResolveInfo[k];
+        int sr = siReferred[k];
+        if (sri != 0) cos.writeUInt32(1, sri);
+        if (sr != 0) cos.writeUInt32(2, sr);
+      }
+    }
+
+    // field 6: si_annotations (packed repeated uint32)
+    if (plan.annotationIndexes != null) {
+      cos.writeTag(6, WireFormat.WIRETYPE_LENGTH_DELIMITED);
+      cos.writeUInt32NoTag(plan.annotPackedRawSize);
+      for (int annIdx : plan.annotationIndexes) cos.writeUInt32NoTag(annIdx);
+    }
+
+    // field 7: si_parent
+    if (plan.siParent != 0) cos.writeUInt32(7, plan.siParent);
+  }
+
+  // ---- Helpers ----
 
   /** UTF-8 byte count for {@code s} without allocating a byte array. */
   static int utf8ByteCount(String s) {
@@ -205,8 +529,8 @@ final class DirectProtoBufSerializer {
       } else if (c < 0x800) {
         count += 2;
       } else if (Character.isHighSurrogate(c)) {
-        count += 4; // surrogate pair → 4 UTF-8 bytes
-        i++; // consume low surrogate
+        count += 4; // valid surrogate pair → 4 UTF-8 bytes; consume low surrogate
+        i++;
       } else {
         count += 3;
       }
@@ -214,246 +538,15 @@ final class DirectProtoBufSerializer {
     return count;
   }
 
-  /** Varint encoding size of an unsigned 32-bit value. */
   private static int varintSize(int v) {
     return CodedOutputStream.computeUInt32SizeNoTag(v);
   }
 
-  /**
-   * Wire size of a uint32 field (tag=1 byte + varint). Returns 0 when {@code value==0} because
-   * proto3 singular fields at their default value are not emitted.
-   */
   private static int uint32FieldSize(int value) {
     return value == 0 ? 0 : 1 + varintSize(value);
   }
 
-  /** Wire size of a string LEN field: tag(1) + varint(utf8Len) + utf8Len. */
-  private static int stringFieldSize(String s) {
-    int utf8Len = utf8ByteCount(s);
-    return 1 + varintSize(utf8Len) + utf8Len;
-  }
-
-  private static int metaPointerBodySize(SerializeState state, MetaPointer mp) {
-    int liLanguage = state.languageIndex.getOrDefault(mp.getLanguageVersion(), 0);
-    int siKey = mp.getKey() != null ? state.stringIndex.getOrDefault(mp.getKey(), 0) : 0;
-    return uint32FieldSize(liLanguage) + uint32FieldSize(siKey);
-  }
-
-  private static int languageBodySize(SerializeState state, LanguageVersion lv) {
-    int siKey = lv.getKey() != null ? state.stringIndex.getOrDefault(lv.getKey(), 0) : 0;
-    int siVersion =
-        lv.getVersion() != null ? state.stringIndex.getOrDefault(lv.getVersion(), 0) : 0;
-    return uint32FieldSize(siKey) + uint32FieldSize(siVersion);
-  }
-
-  private static int referenceValueBodySize(int siResolveInfo, int siReferred) {
-    return uint32FieldSize(siResolveInfo) + uint32FieldSize(siReferred);
-  }
-
-  /** Computes the total chunk byte size from pre-computed node body sizes. */
-  private static int computeChunkSize(
-      SerializationChunk chunk, SerializeState state, int[] nodeBodySizes) {
-    int size = 0;
-
-    // field 1: serialization_format_version
-    String version = chunk.getSerializationFormatVersion();
-    if (version != null && !version.isEmpty()) {
-      size += stringFieldSize(version);
-    }
-
-    // field 2: interned_strings (index 0 = null, skip it)
-    for (int i = 1, n = state.strings.size(); i < n; i++) {
-      size += stringFieldSize(state.strings.get(i));
-    }
-
-    // field 3: interned_meta_pointers
-    for (MetaPointer mp : state.metaPointers) {
-      int bodySize = metaPointerBodySize(state, mp);
-      size += 1 + varintSize(bodySize) + bodySize;
-    }
-
-    // field 4: interned_languages (index 0 = null, skip it)
-    for (int i = 1, n = state.languages.size(); i < n; i++) {
-      LanguageVersion lv = state.languages.get(i);
-      int bodySize = languageBodySize(state, lv);
-      size += 1 + varintSize(bodySize) + bodySize;
-    }
-
-    // field 5: nodes — sizes already computed by visitAndComputeBodySize
-    for (int bodySize : nodeBodySizes) {
-      size += 1 + varintSize(bodySize) + bodySize;
-    }
-
-    return size;
-  }
-
-  // ---- Write phase (Phase 3) ----
-
-  private static void writeChunk(
-      CodedOutputStream cos,
-      SerializationChunk chunk,
-      SerializeState state,
-      List<SerializedClassifierInstance> instances,
-      int[] nodeBodySizes,
-      boolean serializeEmptyFeatures)
-      throws IOException {
-
-    // field 1: serialization_format_version
-    String version = chunk.getSerializationFormatVersion();
-    if (version != null && !version.isEmpty()) {
-      cos.writeString(1, version);
-    }
-
-    // field 2: interned_strings
-    for (int i = 1, n = state.strings.size(); i < n; i++) {
-      cos.writeString(2, state.strings.get(i));
-    }
-
-    // field 3: interned_meta_pointers
-    for (MetaPointer mp : state.metaPointers) {
-      int bodySize = metaPointerBodySize(state, mp);
-      cos.writeTag(3, WireFormat.WIRETYPE_LENGTH_DELIMITED);
-      cos.writeUInt32NoTag(bodySize);
-      int liLanguage = state.languageIndex.getOrDefault(mp.getLanguageVersion(), 0);
-      int siKey = mp.getKey() != null ? state.stringIndex.getOrDefault(mp.getKey(), 0) : 0;
-      if (liLanguage != 0) cos.writeUInt32(1, liLanguage);
-      if (siKey != 0) cos.writeUInt32(2, siKey);
-    }
-
-    // field 4: interned_languages
-    for (int i = 1, n = state.languages.size(); i < n; i++) {
-      LanguageVersion lv = state.languages.get(i);
-      int bodySize = languageBodySize(state, lv);
-      cos.writeTag(4, WireFormat.WIRETYPE_LENGTH_DELIMITED);
-      cos.writeUInt32NoTag(bodySize);
-      int siKey = lv.getKey() != null ? state.stringIndex.getOrDefault(lv.getKey(), 0) : 0;
-      int siVersion =
-          lv.getVersion() != null ? state.stringIndex.getOrDefault(lv.getVersion(), 0) : 0;
-      if (siKey != 0) cos.writeUInt32(1, siKey);
-      if (siVersion != 0) cos.writeUInt32(2, siVersion);
-    }
-
-    // field 5: nodes — use pre-computed body sizes
-    for (int i = 0, n = instances.size(); i < n; i++) {
-      cos.writeTag(5, WireFormat.WIRETYPE_LENGTH_DELIMITED);
-      cos.writeUInt32NoTag(nodeBodySizes[i]);
-      writeNodeBody(cos, instances.get(i), state, serializeEmptyFeatures);
-    }
-  }
-
-  private static void writeNodeBody(
-      CodedOutputStream cos,
-      SerializedClassifierInstance n,
-      SerializeState state,
-      boolean serializeEmptyFeatures)
-      throws IOException {
-
-    // field 1: si_id
-    int siId = n.getID() != null ? state.stringIndex.getOrDefault(n.getID(), 0) : 0;
-    if (siId != 0) cos.writeUInt32(1, siId);
-
-    // field 2: mpi_classifier
-    int mpiClassifier =
-        n.getClassifier() != null ? state.metaPointerIndex.getOrDefault(n.getClassifier(), 0) : 0;
-    if (mpiClassifier != 0) cos.writeUInt32(2, mpiClassifier);
-
-    // field 3: properties
-    for (SerializedPropertyValue p : n.getProperties()) {
-      String value = p.getValue();
-      if (serializeEmptyFeatures || value != null) {
-        int mpiIndex =
-            p.getMetaPointer() != null
-                ? state.metaPointerIndex.getOrDefault(p.getMetaPointer(), 0)
-                : 0;
-        int siValue = value != null ? state.stringIndex.getOrDefault(value, 0) : 0;
-        int bodySize = uint32FieldSize(mpiIndex) + uint32FieldSize(siValue);
-        cos.writeTag(3, WireFormat.WIRETYPE_LENGTH_DELIMITED);
-        cos.writeUInt32NoTag(bodySize);
-        if (mpiIndex != 0) cos.writeUInt32(1, mpiIndex);
-        if (siValue != 0) cos.writeUInt32(2, siValue);
-      }
-    }
-
-    // field 4: containments — compute 'packed' once for both the length prefix and the write loop
-    for (SerializedContainmentValue c : n.getContainments()) {
-      List<String> children = c.getChildrenIds();
-      if (serializeEmptyFeatures || !children.isEmpty()) {
-        int mpiIndex =
-            c.getMetaPointer() != null
-                ? state.metaPointerIndex.getOrDefault(c.getMetaPointer(), 0)
-                : 0;
-        int packed = 0;
-        for (String childId : children) packed += varintSize(state.stringIndex.get(childId));
-        int packedFieldSize = children.isEmpty() ? 0 : (1 + varintSize(packed) + packed);
-        int bodySize = uint32FieldSize(mpiIndex) + packedFieldSize;
-        cos.writeTag(4, WireFormat.WIRETYPE_LENGTH_DELIMITED);
-        cos.writeUInt32NoTag(bodySize);
-        if (mpiIndex != 0) cos.writeUInt32(1, mpiIndex);
-        if (!children.isEmpty()) {
-          cos.writeTag(2, WireFormat.WIRETYPE_LENGTH_DELIMITED);
-          cos.writeUInt32NoTag(packed);
-          for (String childId : children) cos.writeUInt32NoTag(state.stringIndex.get(childId));
-        }
-      }
-    }
-
-    // field 5: references
-    for (SerializedReferenceValue r : n.getReferences()) {
-      List<SerializedReferenceValue.Entry> entries = r.getValue();
-      if (serializeEmptyFeatures || !entries.isEmpty()) {
-        int mpiIndex =
-            r.getMetaPointer() != null
-                ? state.metaPointerIndex.getOrDefault(r.getMetaPointer(), 0)
-                : 0;
-        int refBodySize = uint32FieldSize(mpiIndex);
-        for (SerializedReferenceValue.Entry entry : entries) {
-          int siReferred =
-              entry.getReference() != null
-                  ? state.stringIndex.getOrDefault(entry.getReference(), 0)
-                  : 0;
-          int siResolveInfo =
-              entry.getResolveInfo() != null
-                  ? state.stringIndex.getOrDefault(entry.getResolveInfo(), 0)
-                  : 0;
-          int rvBody = referenceValueBodySize(siResolveInfo, siReferred);
-          refBodySize += 1 + varintSize(rvBody) + rvBody;
-        }
-        cos.writeTag(5, WireFormat.WIRETYPE_LENGTH_DELIMITED);
-        cos.writeUInt32NoTag(refBodySize);
-        if (mpiIndex != 0) cos.writeUInt32(1, mpiIndex);
-        for (SerializedReferenceValue.Entry entry : entries) {
-          int siReferred =
-              entry.getReference() != null
-                  ? state.stringIndex.getOrDefault(entry.getReference(), 0)
-                  : 0;
-          int siResolveInfo =
-              entry.getResolveInfo() != null
-                  ? state.stringIndex.getOrDefault(entry.getResolveInfo(), 0)
-                  : 0;
-          int rvBody = referenceValueBodySize(siResolveInfo, siReferred);
-          cos.writeTag(2, WireFormat.WIRETYPE_LENGTH_DELIMITED);
-          cos.writeUInt32NoTag(rvBody);
-          if (siResolveInfo != 0) cos.writeUInt32(1, siResolveInfo);
-          if (siReferred != 0) cos.writeUInt32(2, siReferred);
-        }
-      }
-    }
-
-    // field 6: si_annotations (packed repeated uint32)
-    List<String> annotations = n.getAnnotations();
-    if (!annotations.isEmpty()) {
-      int packed = 0;
-      for (String annId : annotations)
-        packed += varintSize(state.stringIndex.getOrDefault(annId, 0));
-      cos.writeTag(6, WireFormat.WIRETYPE_LENGTH_DELIMITED);
-      cos.writeUInt32NoTag(packed);
-      for (String annId : annotations)
-        cos.writeUInt32NoTag(state.stringIndex.getOrDefault(annId, 0));
-    }
-
-    // field 7: si_parent
-    int siParent =
-        n.getParentNodeID() != null ? state.stringIndex.getOrDefault(n.getParentNodeID(), 0) : 0;
-    if (siParent != 0) cos.writeUInt32(7, siParent);
+  private static int hashCapacity(int expectedSize) {
+    return Math.max(16, (int) (expectedSize / 0.75f) + 1);
   }
 }

--- a/core/src/main/java/io/lionweb/serialization/DirectProtoBufSerializer.java
+++ b/core/src/main/java/io/lionweb/serialization/DirectProtoBufSerializer.java
@@ -1,5 +1,7 @@
 package io.lionweb.serialization;
 
+import static io.lionweb.serialization.ProtoBufFieldNumbers.*;
+
 import com.google.protobuf.CodedOutputStream;
 import com.google.protobuf.WireFormat;
 import io.lionweb.serialization.data.*;
@@ -539,40 +541,40 @@ final class DirectProtoBufSerializer {
     // field 1: serialization_format_version
     String version = chunk.getSerializationFormatVersion();
     if (version != null && !version.isEmpty()) {
-      cos.writeString(1, version);
+      cos.writeString(CHUNK_SERIALIZATION_FORMAT_VERSION, version);
     }
 
     // field 2: interned_strings
     List<String> strings = state.strings;
     for (int i = 1; i < strings.size(); i++) {
-      cos.writeString(2, strings.get(i));
+      cos.writeString(CHUNK_INTERNED_STRINGS, strings.get(i));
     }
 
     // field 3: interned_meta_pointers — use cached integer arrays, no map lookups
     int mpCount = cached.mpBodySizes.length;
     for (int i = 0; i < mpCount; i++) {
-      cos.writeTag(3, WireFormat.WIRETYPE_LENGTH_DELIMITED);
+      cos.writeTag(CHUNK_INTERNED_META_POINTERS, WireFormat.WIRETYPE_LENGTH_DELIMITED);
       cos.writeUInt32NoTag(cached.mpBodySizes[i]);
       int li = cached.mpLiLanguage[i];
       int sk = cached.mpSiKey[i];
-      if (li != 0) cos.writeUInt32(1, li);
-      if (sk != 0) cos.writeUInt32(2, sk);
+      if (li != 0) cos.writeUInt32(META_POINTER_LI_LANGUAGE, li);
+      if (sk != 0) cos.writeUInt32(META_POINTER_SI_KEY, sk);
     }
 
     // field 4: interned_languages — use cached integer arrays, no map lookups
     int langCount = cached.langBodySizes.length;
     for (int i = 0; i < langCount; i++) {
-      cos.writeTag(4, WireFormat.WIRETYPE_LENGTH_DELIMITED);
+      cos.writeTag(CHUNK_INTERNED_LANGUAGES, WireFormat.WIRETYPE_LENGTH_DELIMITED);
       cos.writeUInt32NoTag(cached.langBodySizes[i]);
       int sk = cached.langSiKey[i];
       int sv = cached.langSiVersion[i];
-      if (sk != 0) cos.writeUInt32(1, sk);
-      if (sv != 0) cos.writeUInt32(2, sv);
+      if (sk != 0) cos.writeUInt32(LANGUAGE_SI_KEY, sk);
+      if (sv != 0) cos.writeUInt32(LANGUAGE_SI_VERSION, sv);
     }
 
     // field 5: nodes — written entirely from plan, zero map lookups
     for (int ni = 0; ni < plan.nodeCount; ni++) {
-      cos.writeTag(5, WireFormat.WIRETYPE_LENGTH_DELIMITED);
+      cos.writeTag(CHUNK_NODES, WireFormat.WIRETYPE_LENGTH_DELIMITED);
       cos.writeUInt32NoTag(plan.nodeBodySize[ni]);
       writeNodeBody(cos, plan, ni);
     }
@@ -582,34 +584,34 @@ final class DirectProtoBufSerializer {
       throws IOException {
     // field 1: si_id
     int siId = plan.nodeSiId[ni];
-    if (siId != 0) cos.writeUInt32(1, siId);
+    if (siId != 0) cos.writeUInt32(NODE_SI_ID, siId);
 
     // field 2: mpi_classifier
     int mpiClassifier = plan.nodeMpiClassifier[ni];
-    if (mpiClassifier != 0) cos.writeUInt32(2, mpiClassifier);
+    if (mpiClassifier != 0) cos.writeUInt32(NODE_MPI_CLASSIFIER, mpiClassifier);
 
     // field 3: properties
     int propEnd = plan.nodePropStart[ni] + plan.nodePropCount[ni];
     for (int i = plan.nodePropStart[ni]; i < propEnd; i++) {
       int bodySize = plan.propBodySize[i];
-      cos.writeTag(3, WireFormat.WIRETYPE_LENGTH_DELIMITED);
+      cos.writeTag(NODE_PROPERTIES, WireFormat.WIRETYPE_LENGTH_DELIMITED);
       cos.writeUInt32NoTag(bodySize);
       int mpi = plan.propMpi[i];
       int sv = plan.propSiValue[i];
-      if (mpi != 0) cos.writeUInt32(1, mpi);
-      if (sv != 0) cos.writeUInt32(2, sv);
+      if (mpi != 0) cos.writeUInt32(PROPERTY_MPI, mpi);
+      if (sv != 0) cos.writeUInt32(PROPERTY_SI_VALUE, sv);
     }
 
     // field 4: containments
     int contEnd = plan.nodeContStart[ni] + plan.nodeContCount[ni];
     for (int i = plan.nodeContStart[ni]; i < contEnd; i++) {
-      cos.writeTag(4, WireFormat.WIRETYPE_LENGTH_DELIMITED);
+      cos.writeTag(NODE_CONTAINMENTS, WireFormat.WIRETYPE_LENGTH_DELIMITED);
       cos.writeUInt32NoTag(plan.contBodySize[i]);
       int mpi = plan.contMpi[i];
-      if (mpi != 0) cos.writeUInt32(1, mpi);
+      if (mpi != 0) cos.writeUInt32(CONTAINMENT_MPI, mpi);
       int nChildren = plan.contChildCount[i];
       if (nChildren > 0) {
-        cos.writeTag(2, WireFormat.WIRETYPE_LENGTH_DELIMITED);
+        cos.writeTag(CONTAINMENT_SI_CHILDREN, WireFormat.WIRETYPE_LENGTH_DELIMITED);
         cos.writeUInt32NoTag(plan.contPackedRawSize[i]);
         int childEnd = plan.contChildStart[i] + nChildren;
         for (int k = plan.contChildStart[i]; k < childEnd; k++) {
@@ -621,26 +623,26 @@ final class DirectProtoBufSerializer {
     // field 5: references
     int refEnd = plan.nodeRefStart[ni] + plan.nodeRefCount[ni];
     for (int i = plan.nodeRefStart[ni]; i < refEnd; i++) {
-      cos.writeTag(5, WireFormat.WIRETYPE_LENGTH_DELIMITED);
+      cos.writeTag(NODE_REFERENCES, WireFormat.WIRETYPE_LENGTH_DELIMITED);
       cos.writeUInt32NoTag(plan.refBodySize[i]);
       int mpi = plan.refMpi[i];
-      if (mpi != 0) cos.writeUInt32(1, mpi);
+      if (mpi != 0) cos.writeUInt32(REFERENCE_MPI, mpi);
       int entryEnd = plan.refEntryStart[i] + plan.refEntryCount[i];
       for (int k = plan.refEntryStart[i]; k < entryEnd; k++) {
         int rvBody = plan.refEntryBodySize[k];
-        cos.writeTag(2, WireFormat.WIRETYPE_LENGTH_DELIMITED);
+        cos.writeTag(REFERENCE_ENTRIES, WireFormat.WIRETYPE_LENGTH_DELIMITED);
         cos.writeUInt32NoTag(rvBody);
         int sri = plan.refEntrySiResolveInfo[k];
         int sr = plan.refEntrySiReferred[k];
-        if (sri != 0) cos.writeUInt32(1, sri);
-        if (sr != 0) cos.writeUInt32(2, sr);
+        if (sri != 0) cos.writeUInt32(REFERENCE_VALUE_SI_RESOLVE_INFO, sri);
+        if (sr != 0) cos.writeUInt32(REFERENCE_VALUE_SI_REFERRED, sr);
       }
     }
 
     // field 6: si_annotations (packed repeated uint32)
     int annotCnt = plan.nodeAnnotCount[ni];
     if (annotCnt > 0) {
-      cos.writeTag(6, WireFormat.WIRETYPE_LENGTH_DELIMITED);
+      cos.writeTag(NODE_SI_ANNOTATIONS, WireFormat.WIRETYPE_LENGTH_DELIMITED);
       cos.writeUInt32NoTag(plan.nodeAnnotPackedRawSize[ni]);
       int annotEnd = plan.nodeAnnotStart[ni] + annotCnt;
       for (int k = plan.nodeAnnotStart[ni]; k < annotEnd; k++) {
@@ -650,7 +652,7 @@ final class DirectProtoBufSerializer {
 
     // field 7: si_parent
     int siParent = plan.nodeSiParent[ni];
-    if (siParent != 0) cos.writeUInt32(7, siParent);
+    if (siParent != 0) cos.writeUInt32(NODE_SI_PARENT, siParent);
   }
 
   /** UTF-8 byte count for {@code s} without allocating a byte array. */

--- a/core/src/main/java/io/lionweb/serialization/DirectProtoBufSerializer.java
+++ b/core/src/main/java/io/lionweb/serialization/DirectProtoBufSerializer.java
@@ -125,7 +125,7 @@ final class DirectProtoBufSerializer {
     // Parallel to state.metaPointers (0-indexed)
     final int[] mpBodySizes;
     final int[] mpLiLanguage; // language index for each meta-pointer
-    final int[] mpSiKey;      // key string index for each meta-pointer
+    final int[] mpSiKey; // key string index for each meta-pointer
 
     // Parallel to state.languages (1-indexed; [i] corresponds to languages[i+1])
     final int[] langBodySizes;
@@ -146,10 +146,11 @@ final class DirectProtoBufSerializer {
       for (int i = 0; i < mpCount; i++) {
         MetaPointer mp = state.metaPointers.get(i);
         // At this point all entries are guaranteed to be in the maps; use get() not getOrDefault()
-        int li = mp.getLanguageVersion() != null
-            ? requireIndex(state.languageIndex, mp.getLanguageVersion(), "LanguageVersion") : 0;
-        int sk = mp.getKey() != null
-            ? requireIndex(state.stringIndex, mp.getKey(), "string") : 0;
+        int li =
+            mp.getLanguageVersion() != null
+                ? requireIndex(state.languageIndex, mp.getLanguageVersion(), "LanguageVersion")
+                : 0;
+        int sk = mp.getKey() != null ? requireIndex(state.stringIndex, mp.getKey(), "string") : 0;
         mpLiLanguage[i] = li;
         mpSiKey[i] = sk;
         mpBodySizes[i] = uint32FieldSize(li) + uint32FieldSize(sk);
@@ -161,10 +162,11 @@ final class DirectProtoBufSerializer {
       langSiVersion = new int[langCount];
       for (int i = 0; i < langCount; i++) {
         LanguageVersion lv = state.languages.get(i + 1);
-        int sk = lv.getKey() != null
-            ? requireIndex(state.stringIndex, lv.getKey(), "string") : 0;
-        int sv = lv.getVersion() != null
-            ? requireIndex(state.stringIndex, lv.getVersion(), "string") : 0;
+        int sk = lv.getKey() != null ? requireIndex(state.stringIndex, lv.getKey(), "string") : 0;
+        int sv =
+            lv.getVersion() != null
+                ? requireIndex(state.stringIndex, lv.getVersion(), "string")
+                : 0;
         langSiKey[i] = sk;
         langSiVersion[i] = sv;
         langBodySizes[i] = uint32FieldSize(sk) + uint32FieldSize(sv);
@@ -224,7 +226,8 @@ final class DirectProtoBufSerializer {
     plan.siParent = n.getParentNodeID() != null ? state.stringIndexer(n.getParentNodeID()) : 0;
 
     // field 2: mpi_classifier
-    plan.mpiClassifier = n.getClassifier() != null ? state.metaPointerIndexer(n.getClassifier()) : 0;
+    plan.mpiClassifier =
+        n.getClassifier() != null ? state.metaPointerIndexer(n.getClassifier()) : 0;
 
     int bodySize = uint32FieldSize(plan.siId) + uint32FieldSize(plan.mpiClassifier);
 
@@ -319,7 +322,8 @@ final class DirectProtoBufSerializer {
             SerializedReferenceValue.Entry entry = entries.get(k);
             // Match legacy: referred indexed before resolveInfo
             int sr = entry.getReference() != null ? state.stringIndexer(entry.getReference()) : 0;
-            int sri = entry.getResolveInfo() != null ? state.stringIndexer(entry.getResolveInfo()) : 0;
+            int sri =
+                entry.getResolveInfo() != null ? state.stringIndexer(entry.getResolveInfo()) : 0;
             int rvBody = uint32FieldSize(sri) + uint32FieldSize(sr);
             siResolveInfo[k] = sri;
             siReferred[k] = sr;

--- a/core/src/main/java/io/lionweb/serialization/DirectProtoBufSerializer.java
+++ b/core/src/main/java/io/lionweb/serialization/DirectProtoBufSerializer.java
@@ -9,23 +9,24 @@ import java.util.*;
 /**
  * Serializes a {@link SerializationChunk} directly to the protobuf binary format without creating
  * intermediate protobuf message objects (PBChunk, PBNode, etc.).
- *
- * <p>Strategy:
- *
- * <ol>
- *   <li>Traverse all nodes once to populate string / language / meta-pointer intern tables and
- *       build a {@link SerializationPlan} containing every integer index and pre-computed body size
- *       needed for writing.
- *   <li>Build a {@link CachedTables} containing UTF-8 lengths, meta-pointer body sizes, and
- *       language body sizes derived from the now-complete intern tables.
- *   <li>Compute the exact total byte count without touching domain objects.
- *   <li>Allocate one {@code byte[]} and write from the plan — zero HashMap lookups, zero domain-
- *       object traversal.
- * </ol>
- *
- * <p>The output is byte-for-byte identical to standard protobuf serialization of a PBChunk message.
  */
 final class DirectProtoBufSerializer {
+  // <p>Strategy:
+  //
+  // <ol>
+  //   <li>Traverse all nodes once to populate string / language / meta-pointer intern tables and
+  //       build a {@link SerializationPlan} containing every integer index and pre-computed body
+  // size
+  //       needed for writing.
+  //   <li>Build a {@link CachedTables} containing UTF-8 lengths, meta-pointer body sizes, and
+  //       language body sizes derived from the now-complete intern tables.
+  //   <li>Compute the exact total byte count without touching domain objects.
+  //   <li>Allocate one {@code byte[]} and write from the plan — zero HashMap lookups, zero domain-
+  //       object traversal.
+  // </ol>
+  //
+  // <p>The output is byte-for-byte identical to standard protobuf serialization of a PBChunk
+  // message.
 
   private DirectProtoBufSerializer() {}
 
@@ -89,9 +90,8 @@ final class DirectProtoBufSerializer {
   }
 
   /**
-   * Flat serialization plan for all nodes. Replaces the per-node {@code NodePlan[]} object graph
-   * with a single struct of parallel int[] arrays for improved cache locality and reduced GC
-   * pressure.
+   * Flat serialization plan for all nodes. Provides a single struct of parallel int[] arrays for
+   * improved cache locality and reduced GC pressure.
    *
    * <p>Node-level data (one entry per node) is stored in parallel arrays indexed by node index.
    * Feature data (properties, containments, references, annotations) is stored in flat arrays; each
@@ -177,10 +177,6 @@ final class DirectProtoBufSerializer {
     int[] rawBuffer() {
       return data;
     }
-
-    int[] toArray() {
-      return Arrays.copyOf(data, size);
-    }
   }
 
   /**
@@ -251,8 +247,6 @@ final class DirectProtoBufSerializer {
     }
   }
 
-  // ---- Public entry point ----
-
   static byte[] serialize(SerializationChunk chunk, boolean serializeEmptyFeatures) {
     List<SerializedClassifierInstance> instances = chunk.getClassifierInstances();
     int nodeCount = instances.size();
@@ -278,8 +272,6 @@ final class DirectProtoBufSerializer {
     }
     return result;
   }
-
-  // ---- Plan building ----
 
   private static SerializationPlan buildSerializationPlan(
       SerializeState state,
@@ -471,7 +463,6 @@ final class DirectProtoBufSerializer {
     plan.nodeAnnotCount = nodeAnnotCount;
     plan.nodeAnnotPackedRawSize = nodeAnnotPackedRawSize;
 
-    // Use rawBuffer() to skip 17 Arrays.copyOf calls — access is always bounded by start+count.
     plan.propMpi = propMpi.rawBuffer();
     plan.propSiValue = propSiValue.rawBuffer();
     plan.propBodySize = propBodySize.rawBuffer();
@@ -495,8 +486,6 @@ final class DirectProtoBufSerializer {
 
     return plan;
   }
-
-  // ---- Size computation ----
 
   /** Computes the total serialized byte count from cached tables and plans — no domain objects. */
   private static int computeChunkSize(
@@ -534,8 +523,6 @@ final class DirectProtoBufSerializer {
 
     return size;
   }
-
-  // ---- Write phase ----
 
   /**
    * Writes the entire chunk. No HashMap lookups; no domain-object traversal. All data comes from
@@ -665,8 +652,6 @@ final class DirectProtoBufSerializer {
     int siParent = plan.nodeSiParent[ni];
     if (siParent != 0) cos.writeUInt32(7, siParent);
   }
-
-  // ---- Helpers ----
 
   /** UTF-8 byte count for {@code s} without allocating a byte array. */
   static int utf8ByteCount(String s) {

--- a/core/src/main/java/io/lionweb/serialization/DirectProtoBufSerializer.java
+++ b/core/src/main/java/io/lionweb/serialization/DirectProtoBufSerializer.java
@@ -89,29 +89,98 @@ final class DirectProtoBufSerializer {
   }
 
   /**
-   * Resolved integer indexes and pre-computed body sizes for a single node. Built once; used by
-   * both the size-computation phase and the write phase without any map lookups.
+   * Flat serialization plan for all nodes. Replaces the per-node {@code NodePlan[]} object graph
+   * with a single struct of parallel int[] arrays for improved cache locality and reduced GC
+   * pressure.
+   *
+   * <p>Node-level data (one entry per node) is stored in parallel arrays indexed by node index.
+   * Feature data (properties, containments, references, annotations) is stored in flat arrays; each
+   * node has a start index and count that slice into the relevant flat arrays.
    */
-  static final class NodePlan {
-    int siId, mpiClassifier, siParent, bodySize;
+  static final class SerializationPlan {
+    int nodeCount;
 
-    // Properties: arrays of length propCount (null when propCount == 0)
-    int propCount;
-    int[] propMpi, propSiValue, propBodySize;
+    // Per-node arrays (length == nodeCount)
+    int[] nodeSiId;
+    int[] nodeMpiClassifier;
+    int[] nodeSiParent;
+    int[] nodeBodySize;
 
-    // Containments: arrays of length contCount (null when contCount == 0)
-    int contCount;
-    int[] contMpi, contBodySize, contPackedRawSize;
-    int[][] contChildIndexes; // [contCount][childCount per containment]
+    int[] nodePropStart;
+    int[] nodePropCount;
 
-    // References: arrays of length refCount (null when refCount == 0)
-    int refCount;
-    int[] refMpi, refBodySize;
-    int[][] refSiResolveInfo, refSiReferred, refEntryBodySize;
+    int[] nodeContStart;
+    int[] nodeContCount;
 
-    // Annotations (null when there are no annotations)
-    int[] annotationIndexes;
-    int annotPackedRawSize; // sum of varintSize(annotIdx) — used as the packed-field length prefix
+    int[] nodeRefStart;
+    int[] nodeRefCount;
+
+    int[] nodeAnnotStart;
+    int[] nodeAnnotCount;
+    int[] nodeAnnotPackedRawSize;
+
+    // Flat property arrays
+    int[] propMpi;
+    int[] propSiValue;
+    int[] propBodySize;
+
+    // Flat containment arrays
+    int[] contMpi;
+    int[] contBodySize;
+    int[] contPackedRawSize;
+    int[] contChildStart;
+    int[] contChildCount;
+
+    // Flat children array
+    int[] childIndexes;
+
+    // Flat reference arrays
+    int[] refMpi;
+    int[] refBodySize;
+    int[] refEntryStart;
+    int[] refEntryCount;
+
+    // Flat reference entry arrays
+    int[] refEntrySiResolveInfo;
+    int[] refEntrySiReferred;
+    int[] refEntryBodySize;
+
+    // Flat annotation array
+    int[] annotIndexes;
+  }
+
+  /**
+   * Simple growable int[] builder used to construct flat arrays in one pass.
+   *
+   * <p>Callers that own the appender and use explicit start+count bounds when reading can call
+   * {@link #rawBuffer()} instead of {@link #toArray()} to avoid an {@code Arrays.copyOf} when
+   * assigning to the plan — the extra trailing zeroes are never read.
+   */
+  private static final class IntAppender {
+    int[] data;
+    int size;
+
+    IntAppender(int cap) {
+      data = new int[Math.max(cap, 4)];
+    }
+
+    void add(int v) {
+      if (size == data.length) data = Arrays.copyOf(data, data.length * 2);
+      data[size++] = v;
+    }
+
+    int size() {
+      return size;
+    }
+
+    /** Returns the internal backing array (may be larger than {@link #size()}). */
+    int[] rawBuffer() {
+      return data;
+    }
+
+    int[] toArray() {
+      return Arrays.copyOf(data, size);
+    }
   }
 
   /**
@@ -194,19 +263,16 @@ final class DirectProtoBufSerializer {
 
     SerializeState state = new SerializeState(estimatedStrings, 8, estimatedMetaPointers);
 
-    // Single traversal: populate intern tables AND build per-node plans
-    NodePlan[] plans = new NodePlan[nodeCount];
-    for (int i = 0; i < nodeCount; i++) {
-      plans[i] = buildNodePlan(state, instances.get(i), serializeEmptyFeatures);
-    }
+    // Single traversal: populate intern tables AND build flat plan
+    SerializationPlan plan = buildSerializationPlan(state, instances, serializeEmptyFeatures);
 
     CachedTables cached = new CachedTables(state);
-    int totalSize = computeChunkSize(chunk, cached, plans);
+    int totalSize = computeChunkSize(chunk, cached, plan);
 
     byte[] result = new byte[totalSize];
     CodedOutputStream cos = CodedOutputStream.newInstance(result);
     try {
-      writeChunk(cos, chunk, state, cached, plans);
+      writeChunk(cos, chunk, state, cached, plan);
     } catch (IOException e) {
       throw new IllegalStateException("Unexpected IOException writing to byte array", e);
     }
@@ -215,34 +281,74 @@ final class DirectProtoBufSerializer {
 
   // ---- Plan building ----
 
-  private static NodePlan buildNodePlan(
-      SerializeState state, SerializedClassifierInstance n, boolean serializeEmptyFeatures) {
-    NodePlan plan = new NodePlan();
+  private static SerializationPlan buildSerializationPlan(
+      SerializeState state,
+      List<SerializedClassifierInstance> instances,
+      boolean serializeEmptyFeatures) {
 
-    // field 1: si_id
-    plan.siId = n.getID() != null ? state.stringIndexer(n.getID()) : 0;
+    int nodeCount = instances.size();
 
-    // field 7: si_parent — indexed here (between id and classifier) to match legacy table ordering
-    plan.siParent = n.getParentNodeID() != null ? state.stringIndexer(n.getParentNodeID()) : 0;
+    // Per-node arrays
+    int[] nodeSiId = new int[nodeCount];
+    int[] nodeMpiClassifier = new int[nodeCount];
+    int[] nodeSiParent = new int[nodeCount];
+    int[] nodeBodySize = new int[nodeCount];
+    int[] nodePropStart = new int[nodeCount];
+    int[] nodePropCount = new int[nodeCount];
+    int[] nodeContStart = new int[nodeCount];
+    int[] nodeContCount = new int[nodeCount];
+    int[] nodeRefStart = new int[nodeCount];
+    int[] nodeRefCount = new int[nodeCount];
+    int[] nodeAnnotStart = new int[nodeCount];
+    int[] nodeAnnotCount = new int[nodeCount];
+    int[] nodeAnnotPackedRawSize = new int[nodeCount];
 
-    // field 2: mpi_classifier
-    plan.mpiClassifier =
-        n.getClassifier() != null ? state.metaPointerIndexer(n.getClassifier()) : 0;
+    // Flat feature appenders
+    IntAppender propMpi = new IntAppender(nodeCount * 3);
+    IntAppender propSiValue = new IntAppender(nodeCount * 3);
+    IntAppender propBodySize = new IntAppender(nodeCount * 3);
 
-    int bodySize = uint32FieldSize(plan.siId) + uint32FieldSize(plan.mpiClassifier);
+    IntAppender contMpi = new IntAppender(nodeCount);
+    IntAppender contBodySize = new IntAppender(nodeCount);
+    IntAppender contPackedRawSize = new IntAppender(nodeCount);
+    IntAppender contChildStart = new IntAppender(nodeCount);
+    IntAppender contChildCount = new IntAppender(nodeCount);
 
-    // field 3: properties
-    List<SerializedPropertyValue> propList = n.getProperties();
-    int propCount = 0;
-    for (SerializedPropertyValue p : propList) {
-      if (serializeEmptyFeatures || p.getValue() != null) propCount++;
-    }
-    plan.propCount = propCount;
-    if (propCount > 0) {
-      plan.propMpi = new int[propCount];
-      plan.propSiValue = new int[propCount];
-      plan.propBodySize = new int[propCount];
-      int pi = 0;
+    IntAppender childIndexes = new IntAppender(nodeCount * 2);
+
+    IntAppender refMpi = new IntAppender(nodeCount);
+    IntAppender refBodySize = new IntAppender(nodeCount);
+    IntAppender refEntryStart = new IntAppender(nodeCount);
+    IntAppender refEntryCount = new IntAppender(nodeCount);
+
+    IntAppender refEntrySiResolveInfo = new IntAppender(nodeCount);
+    IntAppender refEntrySiReferred = new IntAppender(nodeCount);
+    IntAppender refEntryBodySize = new IntAppender(nodeCount);
+
+    IntAppender annotIndexes = new IntAppender(nodeCount / 4 + 4);
+
+    for (int ni = 0; ni < nodeCount; ni++) {
+      SerializedClassifierInstance n = instances.get(ni);
+
+      // field 1: si_id
+      int siId = n.getID() != null ? state.stringIndexer(n.getID()) : 0;
+      nodeSiId[ni] = siId;
+
+      // field 7: si_parent — indexed here (between id and classifier) to match legacy table ordering
+      int siParent = n.getParentNodeID() != null ? state.stringIndexer(n.getParentNodeID()) : 0;
+      nodeSiParent[ni] = siParent;
+
+      // field 2: mpi_classifier
+      int mpiClassifier =
+          n.getClassifier() != null ? state.metaPointerIndexer(n.getClassifier()) : 0;
+      nodeMpiClassifier[ni] = mpiClassifier;
+
+      int bodySize = uint32FieldSize(siId) + uint32FieldSize(mpiClassifier);
+
+      // field 3: properties
+      List<SerializedPropertyValue> propList = n.getProperties();
+      int propStart = propMpi.size();
+      int propCnt = 0;
       for (SerializedPropertyValue p : propList) {
         String value = p.getValue();
         if (serializeEmptyFeatures || value != null) {
@@ -250,117 +356,143 @@ final class DirectProtoBufSerializer {
           int siValue = state.stringIndexer(value);
           int mpi = p.getMetaPointer() != null ? state.metaPointerIndexer(p.getMetaPointer()) : 0;
           int pb = uint32FieldSize(mpi) + uint32FieldSize(siValue);
-          plan.propMpi[pi] = mpi;
-          plan.propSiValue[pi] = siValue;
-          plan.propBodySize[pi] = pb;
+          propMpi.add(mpi);
+          propSiValue.add(siValue);
+          propBodySize.add(pb);
           bodySize += 1 + varintSize(pb) + pb;
-          pi++;
+          propCnt++;
         }
       }
-    }
+      nodePropStart[ni] = propStart;
+      nodePropCount[ni] = propCnt;
 
-    // field 4: containments
-    List<SerializedContainmentValue> contList = n.getContainments();
-    int contCount = 0;
-    for (SerializedContainmentValue c : contList) {
-      if (serializeEmptyFeatures || !c.getChildrenIds().isEmpty()) contCount++;
-    }
-    plan.contCount = contCount;
-    if (contCount > 0) {
-      plan.contMpi = new int[contCount];
-      plan.contBodySize = new int[contCount];
-      plan.contPackedRawSize = new int[contCount];
-      plan.contChildIndexes = new int[contCount][];
-      int ci = 0;
+      // field 4: containments
+      List<SerializedContainmentValue> contList = n.getContainments();
+      int contStart = contMpi.size();
+      int contCnt = 0;
       for (SerializedContainmentValue c : contList) {
         List<String> children = c.getChildrenIds();
         if (serializeEmptyFeatures || !children.isEmpty()) {
           int mpi = c.getMetaPointer() != null ? state.metaPointerIndexer(c.getMetaPointer()) : 0;
           int nChildren = children.size();
-          int[] childIdxs = new int[nChildren];
+          int childStart = childIndexes.size();
           int packed = 0;
           for (int k = 0; k < nChildren; k++) {
-            childIdxs[k] = state.stringIndexer(children.get(k));
-            packed += varintSize(childIdxs[k]);
+            int childIdx = state.stringIndexer(children.get(k));
+            childIndexes.add(childIdx);
+            packed += varintSize(childIdx);
           }
           int packedFieldSize = nChildren == 0 ? 0 : (1 + varintSize(packed) + packed);
           int cb = uint32FieldSize(mpi) + packedFieldSize;
-          plan.contMpi[ci] = mpi;
-          plan.contBodySize[ci] = cb;
-          plan.contPackedRawSize[ci] = packed; // raw byte count of the packed content
-          plan.contChildIndexes[ci] = childIdxs;
+          contMpi.add(mpi);
+          contBodySize.add(cb);
+          contPackedRawSize.add(packed);
+          contChildStart.add(childStart);
+          contChildCount.add(nChildren);
           bodySize += 1 + varintSize(cb) + cb;
-          ci++;
+          contCnt++;
         }
       }
-    }
+      nodeContStart[ni] = contStart;
+      nodeContCount[ni] = contCnt;
 
-    // field 5: references
-    List<SerializedReferenceValue> refList = n.getReferences();
-    int refCount = 0;
-    for (SerializedReferenceValue r : refList) {
-      if (serializeEmptyFeatures || !r.getValue().isEmpty()) refCount++;
-    }
-    plan.refCount = refCount;
-    if (refCount > 0) {
-      plan.refMpi = new int[refCount];
-      plan.refBodySize = new int[refCount];
-      plan.refSiResolveInfo = new int[refCount][];
-      plan.refSiReferred = new int[refCount][];
-      plan.refEntryBodySize = new int[refCount][];
-      int ri = 0;
+      // field 5: references
+      List<SerializedReferenceValue> refList = n.getReferences();
+      int refStart = refMpi.size();
+      int refCnt = 0;
       for (SerializedReferenceValue r : refList) {
         List<SerializedReferenceValue.Entry> entries = r.getValue();
         if (serializeEmptyFeatures || !entries.isEmpty()) {
           int mpi = r.getMetaPointer() != null ? state.metaPointerIndexer(r.getMetaPointer()) : 0;
           int nEntries = entries.size();
-          int[] siResolveInfo = new int[nEntries];
-          int[] siReferred = new int[nEntries];
-          int[] entryBodies = new int[nEntries];
+          int entryStart = refEntrySiResolveInfo.size();
           int refBody = uint32FieldSize(mpi);
           for (int k = 0; k < nEntries; k++) {
             SerializedReferenceValue.Entry entry = entries.get(k);
             // Match legacy: referred indexed before resolveInfo
-            int sr = entry.getReference() != null ? state.stringIndexer(entry.getReference()) : 0;
+            int sr =
+                entry.getReference() != null ? state.stringIndexer(entry.getReference()) : 0;
             int sri =
                 entry.getResolveInfo() != null ? state.stringIndexer(entry.getResolveInfo()) : 0;
             int rvBody = uint32FieldSize(sri) + uint32FieldSize(sr);
-            siResolveInfo[k] = sri;
-            siReferred[k] = sr;
-            entryBodies[k] = rvBody;
+            refEntrySiResolveInfo.add(sri);
+            refEntrySiReferred.add(sr);
+            refEntryBodySize.add(rvBody);
             refBody += 1 + varintSize(rvBody) + rvBody;
           }
-          plan.refMpi[ri] = mpi;
-          plan.refBodySize[ri] = refBody;
-          plan.refSiResolveInfo[ri] = siResolveInfo;
-          plan.refSiReferred[ri] = siReferred;
-          plan.refEntryBodySize[ri] = entryBodies;
+          refMpi.add(mpi);
+          refBodySize.add(refBody);
+          refEntryStart.add(entryStart);
+          refEntryCount.add(nEntries);
           bodySize += 1 + varintSize(refBody) + refBody;
-          ri++;
+          refCnt++;
         }
       }
-    }
+      nodeRefStart[ni] = refStart;
+      nodeRefCount[ni] = refCnt;
 
-    // field 6: annotations (packed repeated uint32)
-    List<String> annotations = n.getAnnotations();
-    if (!annotations.isEmpty()) {
-      int nAnn = annotations.size();
-      int[] annIdxs = new int[nAnn];
+      // field 6: annotations (packed repeated uint32)
+      List<String> annotations = n.getAnnotations();
+      int annotStart = annotIndexes.size();
+      int annotCnt = annotations.size();
       int packed = 0;
-      for (int k = 0; k < nAnn; k++) {
+      for (int k = 0; k < annotCnt; k++) {
         // null annotation IDs map to index 0 (preserved from legacy getOrDefault behavior)
-        annIdxs[k] = state.stringIndexer(annotations.get(k));
-        packed += varintSize(annIdxs[k]);
+        int annIdx = state.stringIndexer(annotations.get(k));
+        annotIndexes.add(annIdx);
+        packed += varintSize(annIdx);
       }
-      plan.annotationIndexes = annIdxs;
-      plan.annotPackedRawSize = packed;
-      bodySize += 1 + varintSize(packed) + packed;
+      nodeAnnotStart[ni] = annotStart;
+      nodeAnnotCount[ni] = annotCnt;
+      nodeAnnotPackedRawSize[ni] = packed;
+      if (annotCnt > 0) {
+        bodySize += 1 + varintSize(packed) + packed;
+      }
+
+      // field 7: si_parent size (index already set above for table-ordering purposes)
+      bodySize += uint32FieldSize(siParent);
+
+      nodeBodySize[ni] = bodySize;
     }
 
-    // field 7: si_parent size (index already set above for table-ordering purposes)
-    bodySize += uint32FieldSize(plan.siParent);
+    SerializationPlan plan = new SerializationPlan();
+    plan.nodeCount = nodeCount;
+    plan.nodeSiId = nodeSiId;
+    plan.nodeMpiClassifier = nodeMpiClassifier;
+    plan.nodeSiParent = nodeSiParent;
+    plan.nodeBodySize = nodeBodySize;
+    plan.nodePropStart = nodePropStart;
+    plan.nodePropCount = nodePropCount;
+    plan.nodeContStart = nodeContStart;
+    plan.nodeContCount = nodeContCount;
+    plan.nodeRefStart = nodeRefStart;
+    plan.nodeRefCount = nodeRefCount;
+    plan.nodeAnnotStart = nodeAnnotStart;
+    plan.nodeAnnotCount = nodeAnnotCount;
+    plan.nodeAnnotPackedRawSize = nodeAnnotPackedRawSize;
 
-    plan.bodySize = bodySize;
+    // Use rawBuffer() to skip 17 Arrays.copyOf calls — access is always bounded by start+count.
+    plan.propMpi = propMpi.rawBuffer();
+    plan.propSiValue = propSiValue.rawBuffer();
+    plan.propBodySize = propBodySize.rawBuffer();
+
+    plan.contMpi = contMpi.rawBuffer();
+    plan.contBodySize = contBodySize.rawBuffer();
+    plan.contPackedRawSize = contPackedRawSize.rawBuffer();
+    plan.contChildStart = contChildStart.rawBuffer();
+    plan.contChildCount = contChildCount.rawBuffer();
+    plan.childIndexes = childIndexes.rawBuffer();
+
+    plan.refMpi = refMpi.rawBuffer();
+    plan.refBodySize = refBodySize.rawBuffer();
+    plan.refEntryStart = refEntryStart.rawBuffer();
+    plan.refEntryCount = refEntryCount.rawBuffer();
+    plan.refEntrySiResolveInfo = refEntrySiResolveInfo.rawBuffer();
+    plan.refEntrySiReferred = refEntrySiReferred.rawBuffer();
+    plan.refEntryBodySize = refEntryBodySize.rawBuffer();
+
+    plan.annotIndexes = annotIndexes.rawBuffer();
+
     return plan;
   }
 
@@ -368,7 +500,7 @@ final class DirectProtoBufSerializer {
 
   /** Computes the total serialized byte count from cached tables and plans — no domain objects. */
   private static int computeChunkSize(
-      SerializationChunk chunk, CachedTables cached, NodePlan[] plans) {
+      SerializationChunk chunk, CachedTables cached, SerializationPlan plan) {
     int size = 0;
 
     // field 1: serialization_format_version (not in the intern table; computed ad-hoc)
@@ -395,8 +527,9 @@ final class DirectProtoBufSerializer {
     }
 
     // field 5: nodes
-    for (NodePlan plan : plans) {
-      size += 1 + varintSize(plan.bodySize) + plan.bodySize;
+    for (int ni = 0; ni < plan.nodeCount; ni++) {
+      int bodySize = plan.nodeBodySize[ni];
+      size += 1 + varintSize(bodySize) + bodySize;
     }
 
     return size;
@@ -406,14 +539,14 @@ final class DirectProtoBufSerializer {
 
   /**
    * Writes the entire chunk. No HashMap lookups; no domain-object traversal. All data comes from
-   * {@code cached} arrays and {@code plans}.
+   * {@code cached} arrays and {@code plan}.
    */
   private static void writeChunk(
       CodedOutputStream cos,
       SerializationChunk chunk,
       SerializeState state,
       CachedTables cached,
-      NodePlan[] plans)
+      SerializationPlan plan)
       throws IOException {
 
     // field 1: serialization_format_version
@@ -450,23 +583,27 @@ final class DirectProtoBufSerializer {
       if (sv != 0) cos.writeUInt32(2, sv);
     }
 
-    // field 5: nodes — written entirely from plans, zero map lookups
-    for (NodePlan plan : plans) {
+    // field 5: nodes — written entirely from plan, zero map lookups
+    for (int ni = 0; ni < plan.nodeCount; ni++) {
       cos.writeTag(5, WireFormat.WIRETYPE_LENGTH_DELIMITED);
-      cos.writeUInt32NoTag(plan.bodySize);
-      writeNodeBody(cos, plan);
+      cos.writeUInt32NoTag(plan.nodeBodySize[ni]);
+      writeNodeBody(cos, plan, ni);
     }
   }
 
-  private static void writeNodeBody(CodedOutputStream cos, NodePlan plan) throws IOException {
+  private static void writeNodeBody(CodedOutputStream cos, SerializationPlan plan, int ni)
+      throws IOException {
     // field 1: si_id
-    if (plan.siId != 0) cos.writeUInt32(1, plan.siId);
+    int siId = plan.nodeSiId[ni];
+    if (siId != 0) cos.writeUInt32(1, siId);
 
     // field 2: mpi_classifier
-    if (plan.mpiClassifier != 0) cos.writeUInt32(2, plan.mpiClassifier);
+    int mpiClassifier = plan.nodeMpiClassifier[ni];
+    if (mpiClassifier != 0) cos.writeUInt32(2, mpiClassifier);
 
     // field 3: properties
-    for (int i = 0; i < plan.propCount; i++) {
+    int propEnd = plan.nodePropStart[ni] + plan.nodePropCount[ni];
+    for (int i = plan.nodePropStart[ni]; i < propEnd; i++) {
       int bodySize = plan.propBodySize[i];
       cos.writeTag(3, WireFormat.WIRETYPE_LENGTH_DELIMITED);
       cos.writeUInt32NoTag(bodySize);
@@ -477,48 +614,56 @@ final class DirectProtoBufSerializer {
     }
 
     // field 4: containments
-    for (int i = 0; i < plan.contCount; i++) {
+    int contEnd = plan.nodeContStart[ni] + plan.nodeContCount[ni];
+    for (int i = plan.nodeContStart[ni]; i < contEnd; i++) {
       cos.writeTag(4, WireFormat.WIRETYPE_LENGTH_DELIMITED);
       cos.writeUInt32NoTag(plan.contBodySize[i]);
       int mpi = plan.contMpi[i];
       if (mpi != 0) cos.writeUInt32(1, mpi);
-      int[] childIdxs = plan.contChildIndexes[i];
-      if (childIdxs.length > 0) {
+      int nChildren = plan.contChildCount[i];
+      if (nChildren > 0) {
         cos.writeTag(2, WireFormat.WIRETYPE_LENGTH_DELIMITED);
         cos.writeUInt32NoTag(plan.contPackedRawSize[i]);
-        for (int childIdx : childIdxs) cos.writeUInt32NoTag(childIdx);
+        int childEnd = plan.contChildStart[i] + nChildren;
+        for (int k = plan.contChildStart[i]; k < childEnd; k++) {
+          cos.writeUInt32NoTag(plan.childIndexes[k]);
+        }
       }
     }
 
     // field 5: references
-    for (int i = 0; i < plan.refCount; i++) {
+    int refEnd = plan.nodeRefStart[ni] + plan.nodeRefCount[ni];
+    for (int i = plan.nodeRefStart[ni]; i < refEnd; i++) {
       cos.writeTag(5, WireFormat.WIRETYPE_LENGTH_DELIMITED);
       cos.writeUInt32NoTag(plan.refBodySize[i]);
       int mpi = plan.refMpi[i];
       if (mpi != 0) cos.writeUInt32(1, mpi);
-      int[] siResolveInfo = plan.refSiResolveInfo[i];
-      int[] siReferred = plan.refSiReferred[i];
-      int[] entryBodies = plan.refEntryBodySize[i];
-      for (int k = 0; k < siReferred.length; k++) {
-        int rvBody = entryBodies[k];
+      int entryEnd = plan.refEntryStart[i] + plan.refEntryCount[i];
+      for (int k = plan.refEntryStart[i]; k < entryEnd; k++) {
+        int rvBody = plan.refEntryBodySize[k];
         cos.writeTag(2, WireFormat.WIRETYPE_LENGTH_DELIMITED);
         cos.writeUInt32NoTag(rvBody);
-        int sri = siResolveInfo[k];
-        int sr = siReferred[k];
+        int sri = plan.refEntrySiResolveInfo[k];
+        int sr = plan.refEntrySiReferred[k];
         if (sri != 0) cos.writeUInt32(1, sri);
         if (sr != 0) cos.writeUInt32(2, sr);
       }
     }
 
     // field 6: si_annotations (packed repeated uint32)
-    if (plan.annotationIndexes != null) {
+    int annotCnt = plan.nodeAnnotCount[ni];
+    if (annotCnt > 0) {
       cos.writeTag(6, WireFormat.WIRETYPE_LENGTH_DELIMITED);
-      cos.writeUInt32NoTag(plan.annotPackedRawSize);
-      for (int annIdx : plan.annotationIndexes) cos.writeUInt32NoTag(annIdx);
+      cos.writeUInt32NoTag(plan.nodeAnnotPackedRawSize[ni]);
+      int annotEnd = plan.nodeAnnotStart[ni] + annotCnt;
+      for (int k = plan.nodeAnnotStart[ni]; k < annotEnd; k++) {
+        cos.writeUInt32NoTag(plan.annotIndexes[k]);
+      }
     }
 
     // field 7: si_parent
-    if (plan.siParent != 0) cos.writeUInt32(7, plan.siParent);
+    int siParent = plan.nodeSiParent[ni];
+    if (siParent != 0) cos.writeUInt32(7, siParent);
   }
 
   // ---- Helpers ----

--- a/core/src/main/java/io/lionweb/serialization/ProtoBufFieldNumbers.java
+++ b/core/src/main/java/io/lionweb/serialization/ProtoBufFieldNumbers.java
@@ -1,0 +1,46 @@
+package io.lionweb.serialization;
+
+/** Protobuf field numbers for the LionWeb binary serialization format. */
+final class ProtoBufFieldNumbers {
+  private ProtoBufFieldNumbers() {}
+
+  // PBChunk top-level fields
+  static final int CHUNK_SERIALIZATION_FORMAT_VERSION = 1;
+  static final int CHUNK_INTERNED_STRINGS = 2;
+  static final int CHUNK_INTERNED_META_POINTERS = 3;
+  static final int CHUNK_INTERNED_LANGUAGES = 4;
+  static final int CHUNK_NODES = 5;
+
+  // PBNode fields
+  static final int NODE_SI_ID = 1;
+  static final int NODE_MPI_CLASSIFIER = 2;
+  static final int NODE_PROPERTIES = 3;
+  static final int NODE_CONTAINMENTS = 4;
+  static final int NODE_REFERENCES = 5;
+  static final int NODE_SI_ANNOTATIONS = 6;
+  static final int NODE_SI_PARENT = 7;
+
+  // PBMetaPointer fields
+  static final int META_POINTER_LI_LANGUAGE = 1;
+  static final int META_POINTER_SI_KEY = 2;
+
+  // PBLanguage fields
+  static final int LANGUAGE_SI_KEY = 1;
+  static final int LANGUAGE_SI_VERSION = 2;
+
+  // PBProperty fields
+  static final int PROPERTY_MPI = 1;
+  static final int PROPERTY_SI_VALUE = 2;
+
+  // PBContainment fields
+  static final int CONTAINMENT_MPI = 1;
+  static final int CONTAINMENT_SI_CHILDREN = 2;
+
+  // PBReference fields
+  static final int REFERENCE_MPI = 1;
+  static final int REFERENCE_ENTRIES = 2;
+
+  // PBReferenceValue fields
+  static final int REFERENCE_VALUE_SI_RESOLVE_INFO = 1;
+  static final int REFERENCE_VALUE_SI_REFERRED = 2;
+}

--- a/core/src/main/java/io/lionweb/serialization/ProtoBufSerialization.java
+++ b/core/src/main/java/io/lionweb/serialization/ProtoBufSerialization.java
@@ -21,25 +21,26 @@ public class ProtoBufSerialization extends AbstractSerialization {
     super(lionWebVersion);
   }
 
-    /**
-     * Deserializes an array of bytes into a list of {@code Node} instances using a default
-     * {@code ByteArrayInputStream} for the provided byte array.
-     *
-     * @param bytes The byte array to be deserialized into {@code Node} instances. It must not be null.
-     * @return A list of {@code Node} instances deserialized from the given byte array.
-     * @throws IOException If an I/O error occurs during deserialization.
-     */
+  /**
+   * Deserializes an array of bytes into a list of {@code Node} instances using a default {@code
+   * ByteArrayInputStream} for the provided byte array.
+   *
+   * @param bytes The byte array to be deserialized into {@code Node} instances. It must not be
+   *     null.
+   * @return A list of {@code Node} instances deserialized from the given byte array.
+   * @throws IOException If an I/O error occurs during deserialization.
+   */
   public List<Node> deserializeToNodes(byte[] bytes) throws IOException {
     return deserializeToNodes(new ByteArrayInputStream(bytes));
   }
 
-    /**
-     * Deserializes the given byte array into a {@code SerializationChunk} instance.
-     *
-     * @param bytes The byte array representing serialized data. It must not be null.
-     * @return The deserialized {@code SerializationChunk} instance.
-     * @throws IOException If an I/O error occurs during the deserialization process.
-     */
+  /**
+   * Deserializes the given byte array into a {@code SerializationChunk} instance.
+   *
+   * @param bytes The byte array representing serialized data. It must not be null.
+   * @return The deserialized {@code SerializationChunk} instance.
+   * @throws IOException If an I/O error occurs during the deserialization process.
+   */
   public SerializationChunk deserializeToChunk(byte[] bytes) throws IOException {
     return DirectProtoBufDeserializer.deserialize(bytes, serializeEmptyFeatures);
   }

--- a/core/src/main/java/io/lionweb/serialization/ProtoBufSerialization.java
+++ b/core/src/main/java/io/lionweb/serialization/ProtoBufSerialization.java
@@ -2,6 +2,7 @@ package io.lionweb.serialization;
 
 import io.lionweb.LionWebVersion;
 import io.lionweb.model.ClassifierInstance;
+import io.lionweb.model.Node;
 import io.lionweb.model.impl.ProxyNode;
 import io.lionweb.protobuf.*;
 import io.lionweb.serialization.data.*;
@@ -20,29 +21,56 @@ public class ProtoBufSerialization extends AbstractSerialization {
     super(lionWebVersion);
   }
 
-  public List<io.lionweb.model.Node> deserializeToNodes(byte[] bytes) throws IOException {
+    /**
+     * Deserializes an array of bytes into a list of {@code Node} instances using a default
+     * {@code ByteArrayInputStream} for the provided byte array.
+     *
+     * @param bytes The byte array to be deserialized into {@code Node} instances. It must not be null.
+     * @return A list of {@code Node} instances deserialized from the given byte array.
+     * @throws IOException If an I/O error occurs during deserialization.
+     */
+  public List<Node> deserializeToNodes(byte[] bytes) throws IOException {
     return deserializeToNodes(new ByteArrayInputStream(bytes));
   }
 
+    /**
+     * Deserializes the given byte array into a {@code SerializationChunk} instance.
+     *
+     * @param bytes The byte array representing serialized data. It must not be null.
+     * @return The deserialized {@code SerializationChunk} instance.
+     * @throws IOException If an I/O error occurs during the deserialization process.
+     */
   public SerializationChunk deserializeToChunk(byte[] bytes) throws IOException {
+    return DirectProtoBufDeserializer.deserialize(bytes, serializeEmptyFeatures);
+  }
+
+  /** Legacy deserialization path via protobuf-generated PBChunk — used for benchmarking only. */
+  public SerializationChunk deserializeToChunkViaPbChunk(byte[] bytes) throws IOException {
     PBChunk pbChunk = PBChunk.parseFrom(new ByteArrayInputStream(bytes));
     return deserializeSerializationChunk(pbChunk);
   }
 
-  public List<io.lionweb.model.Node> deserializeToNodes(File file) throws IOException {
+  public List<Node> deserializeToNodes(File file) throws IOException {
     return deserializeToNodes(new FileInputStream(file));
   }
 
-  public List<io.lionweb.model.Node> deserializeToNodes(InputStream inputStream)
-      throws IOException {
-    return deserializeToNodes(PBChunk.parseFrom(inputStream));
+  public List<Node> deserializeToNodes(InputStream inputStream) throws IOException {
+    SerializationChunk chunk =
+        DirectProtoBufDeserializer.deserialize(inputStream, serializeEmptyFeatures);
+    validateSerializationBlock(chunk);
+    List<ClassifierInstance<?>> all = deserializeSerializationChunk(chunk);
+    List<Node> nodes = new ArrayList<>(all.size());
+    for (ClassifierInstance<?> ci : all) {
+      if (ci instanceof Node) nodes.add((Node) ci);
+    }
+    return nodes;
   }
 
-  public List<io.lionweb.model.Node> deserializeToNodes(PBChunk chunk) {
+  public List<Node> deserializeToNodes(PBChunk chunk) {
     List<ClassifierInstance<?>> all = deserializeToClassifierInstances(chunk);
-    List<io.lionweb.model.Node> nodes = new ArrayList<>(all.size());
+    List<Node> nodes = new ArrayList<>(all.size());
     for (ClassifierInstance<?> ci : all) {
-      if (ci instanceof io.lionweb.model.Node) nodes.add((io.lionweb.model.Node) ci);
+      if (ci instanceof Node) nodes.add((Node) ci);
     }
     return nodes;
   }
@@ -209,7 +237,7 @@ public class ProtoBufSerialization extends AbstractSerialization {
   }
 
   public byte[] serializeToByteArray(SerializationChunk serializationChunk) {
-    return serialize(serializationChunk).toByteArray();
+    return DirectProtoBufSerializer.serialize(serializationChunk, serializeEmptyFeatures);
   }
 
   protected class SerializeHelper {

--- a/core/src/main/java/io/lionweb/serialization/ProtoBufSerialization.java
+++ b/core/src/main/java/io/lionweb/serialization/ProtoBufSerialization.java
@@ -45,7 +45,10 @@ public class ProtoBufSerialization extends AbstractSerialization {
     return DirectProtoBufDeserializer.deserialize(bytes, serializeEmptyFeatures);
   }
 
-  /** Legacy deserialization path via protobuf-generated PBChunk — used for benchmarking only. */
+  /**
+   * Legacy deserialization path via protobuf-generated PBChunk — used for benchmarking only. To be
+   * removed in the future
+   */
   public SerializationChunk deserializeToChunkViaPbChunk(byte[] bytes) throws IOException {
     PBChunk pbChunk = PBChunk.parseFrom(new ByteArrayInputStream(bytes));
     return deserializeSerializationChunk(pbChunk);

--- a/core/src/performanceTest/java/io/lionweb/serialization/PerformanceTestOnProtoBufBytes.java
+++ b/core/src/performanceTest/java/io/lionweb/serialization/PerformanceTestOnProtoBufBytes.java
@@ -1,0 +1,197 @@
+package io.lionweb.serialization;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.lionweb.serialization.data.SerializationChunk;
+import java.io.*;
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Performance comparison between the direct protobuf byte serializer/deserializer and the legacy
+ * path that goes through protobuf-generated objects (PBChunk, PBNode, etc.).
+ *
+ * <p>Validates that:
+ *
+ * <ul>
+ *   <li>Direct serialization allocates less memory than the legacy path.
+ *   <li>Direct deserialization allocates less memory than the legacy path.
+ * </ul>
+ *
+ * <p>Reports wall-clock timings and allocation rates for manual verification.
+ */
+@Tag("performance")
+class PerformanceTestOnProtoBufBytes {
+
+  private static SerializationChunk chunk;
+  private static byte[] serializedBytes;
+  private static ProtoBufSerialization pbSerialization;
+
+  @BeforeAll
+  static void setup() throws IOException {
+    InputStream is =
+        PerformanceTestOnProtoBufBytes.class.getResourceAsStream(
+            "/serialization/LargeLanguage.json");
+    assertNotNull(is, "LargeLanguage.json must be on classpath");
+
+    String json;
+    try (BufferedReader reader = new BufferedReader(new InputStreamReader(is))) {
+      json = reader.lines().collect(Collectors.joining("\n"));
+    }
+
+    chunk = new LowLevelJsonSerialization().deserializeSerializationBlock(json);
+    pbSerialization = SerializationProvider.getStandardProtoBufSerialization();
+    serializedBytes = DirectProtoBufSerializer.serialize(chunk, true);
+  }
+
+  // ---- Serialization ----
+
+  @Test
+  void directSerializationFasterAndLessMemory() {
+    Runnable directOp = () -> DirectProtoBufSerializer.serialize(chunk, true);
+    Runnable legacyOp = () -> pbSerialization.serialize(chunk).toByteArray();
+
+    long directAlloc = measureAllocation(directOp);
+    long legacyAlloc = measureAllocation(legacyOp);
+
+    System.out.printf(
+        "[Serialize] direct: %,d B/op  legacy: %,d B/op  ratio: %.2fx%n",
+        directAlloc, legacyAlloc, (double) legacyAlloc / directAlloc);
+
+    // Direct path must allocate less than the legacy path
+    assertTrue(
+        directAlloc < legacyAlloc,
+        String.format(
+            "Direct serializer should allocate less than legacy: direct=%,d  legacy=%,d",
+            directAlloc, legacyAlloc));
+  }
+
+  @Test
+  void directSerializationTime() {
+    int warmup = 20, measure = 30;
+    long directMs =
+        measureTime(() -> DirectProtoBufSerializer.serialize(chunk, true), warmup, measure);
+    long legacyMs =
+        measureTime(() -> pbSerialization.serialize(chunk).toByteArray(), warmup, measure);
+
+    System.out.printf(
+        "[Serialize time] direct: %d ms  legacy: %d ms  speedup: %.2fx%n",
+        directMs, legacyMs, (double) legacyMs / directMs);
+  }
+
+  // ---- Deserialization ----
+
+  @Test
+  void directDeserializationFasterAndLessMemory() throws IOException {
+    Runnable directOp =
+        () -> {
+          try {
+            DirectProtoBufDeserializer.deserialize(serializedBytes, true);
+          } catch (IOException e) {
+            throw new UncheckedIOException(e);
+          }
+        };
+    Runnable legacyOp =
+        () -> {
+          try {
+            pbSerialization.deserializeToChunkViaPbChunk(serializedBytes);
+          } catch (IOException e) {
+            throw new UncheckedIOException(e);
+          }
+        };
+
+    long directAlloc = measureAllocation(directOp);
+    long legacyAlloc = measureAllocation(legacyOp);
+
+    System.out.printf(
+        "[Deserialize] direct: %,d B/op  legacy: %,d B/op  ratio: %.2fx%n",
+        directAlloc, legacyAlloc, (double) legacyAlloc / directAlloc);
+
+    // Direct path must allocate less than the legacy path
+    assertTrue(
+        directAlloc < legacyAlloc,
+        String.format(
+            "Direct deserializer should allocate less than legacy: direct=%,d  legacy=%,d",
+            directAlloc, legacyAlloc));
+  }
+
+  @Test
+  void directDeserializationTime() {
+    Runnable directOp =
+        () -> {
+          try {
+            DirectProtoBufDeserializer.deserialize(serializedBytes, true);
+          } catch (IOException e) {
+            throw new UncheckedIOException(e);
+          }
+        };
+    Runnable legacyOp =
+        () -> {
+          try {
+            pbSerialization.deserializeToChunkViaPbChunk(serializedBytes);
+          } catch (IOException e) {
+            throw new UncheckedIOException(e);
+          }
+        };
+
+    int warmup = 20, measure = 30;
+    long directMs = measureTime(directOp, warmup, measure);
+    long legacyMs = measureTime(legacyOp, warmup, measure);
+
+    System.out.printf(
+        "[Deserialize time] direct: %d ms  legacy: %d ms  speedup: %.2fx%n",
+        directMs, legacyMs, (double) legacyMs / directMs);
+  }
+
+  // ---- Measurement helpers ----
+
+  private static long measureAllocation(Runnable op) {
+    // Warm up the JIT
+    for (int i = 0; i < 10; i++) op.run();
+
+    List<Long> samples = new ArrayList<>(20);
+    for (int i = 0; i < 20; i++) {
+      samples.add(threadAllocatedBytes(op));
+    }
+    samples.sort(Long::compareTo);
+    // Trim top and bottom 4 outliers
+    List<Long> trimmed = samples.subList(4, samples.size() - 4);
+    return trimmed.stream().mapToLong(Long::longValue).sum() / trimmed.size();
+  }
+
+  private static long measureTime(Runnable op, int warmupRuns, int measureRuns) {
+    for (int i = 0; i < warmupRuns; i++) op.run();
+    List<Long> times = new ArrayList<>(measureRuns);
+    for (int i = 0; i < measureRuns; i++) {
+      long t0 = System.currentTimeMillis();
+      op.run();
+      times.add(System.currentTimeMillis() - t0);
+    }
+    times.sort(Long::compareTo);
+    List<Long> trimmed = times.subList(4, times.size() - 4);
+    return trimmed.stream().mapToLong(Long::longValue).sum() / trimmed.size();
+  }
+
+  private static long threadAllocatedBytes(Runnable op) {
+    ThreadMXBean bean = ManagementFactory.getThreadMXBean();
+    if (bean instanceof com.sun.management.ThreadMXBean) {
+      com.sun.management.ThreadMXBean sunBean = (com.sun.management.ThreadMXBean) bean;
+      long id = Thread.currentThread().getId();
+      long before = sunBean.getThreadAllocatedBytes(id);
+      op.run();
+      return sunBean.getThreadAllocatedBytes(id) - before;
+    }
+    // Fallback: GC-based heap delta (less accurate)
+    System.gc();
+    Runtime rt = Runtime.getRuntime();
+    long before = rt.totalMemory() - rt.freeMemory();
+    op.run();
+    return Math.max(0L, rt.totalMemory() - rt.freeMemory() - before);
+  }
+}

--- a/core/src/performanceTest/java/io/lionweb/serialization/ProtoBufBytesBenchmark.java
+++ b/core/src/performanceTest/java/io/lionweb/serialization/ProtoBufBytesBenchmark.java
@@ -1,0 +1,112 @@
+package io.lionweb.serialization;
+
+import io.lionweb.LionWebVersion;
+import io.lionweb.model.Node;
+import io.lionweb.serialization.data.SerializationChunk;
+import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * JMH benchmark comparing the direct protobuf byte serialization/deserialization (via {@link
+ * DirectProtoBufSerializer} / {@link DirectProtoBufDeserializer}) against the previous path that
+ * went through protobuf-generated objects (PBChunk, PBNode, etc.).
+ *
+ * <p>Two pairs of benchmarks:
+ *
+ * <ul>
+ *   <li>{@link #serializeDirect} / {@link #serializeViaPbChunk} — serialize a {@link
+ *       SerializationChunk} to bytes.
+ *   <li>{@link #deserializeDirect} / {@link #deserializeViaPbChunk} — parse bytes back to a {@link
+ *       SerializationChunk}.
+ * </ul>
+ *
+ * <p>Run with {@link #main} to include the GC allocation profiler.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(2)
+@State(Scope.Thread)
+public class ProtoBufBytesBenchmark {
+
+  /** Pre-built SerializationChunk from LargeLanguage.json — the input to serialization. */
+  private SerializationChunk chunk;
+
+  /** Bytes produced by the direct serializer — the input to deserialization. */
+  private byte[] serializedBytes;
+
+  /** Reusable ProtoBufSerialization instance. */
+  private ProtoBufSerialization pbSerialization;
+
+  @Setup(Level.Trial)
+  public void setup() throws IOException {
+    InputStream is = getClass().getResourceAsStream("/serialization/LargeLanguage.json");
+    if (is == null) {
+      throw new IllegalStateException(
+          "Resource /serialization/LargeLanguage.json not found on classpath");
+    }
+    String json;
+    try (BufferedReader reader = new BufferedReader(new InputStreamReader(is))) {
+      json = reader.lines().collect(Collectors.joining("\n"));
+    }
+
+    JsonSerialization setupJs =
+        SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1);
+    List<Node> nodes = setupJs.deserializeToNodes(json);
+
+    pbSerialization = SerializationProvider.getStandardProtoBufSerialization();
+
+    // Build the SerializationChunk once; both benchmarks reuse it
+    chunk = pbSerialization.serializeNodesToSerializationChunk(new ArrayList<>(nodes));
+
+    // Pre-serialize so deserialization benchmarks measure only the parsing side
+    serializedBytes = DirectProtoBufSerializer.serialize(chunk, true);
+  }
+
+  // ---- Serialization benchmarks ----
+
+  /** Direct serializer: SerializationChunk → byte[] without creating PBChunk/PBNode objects. */
+  @Benchmark
+  public byte[] serializeDirect() {
+    return DirectProtoBufSerializer.serialize(chunk, true);
+  }
+
+  /** Legacy path: SerializationChunk → PBChunk → byte[]. */
+  @Benchmark
+  public byte[] serializeViaPbChunk() {
+    return pbSerialization.serialize(chunk).toByteArray();
+  }
+
+  // ---- Deserialization benchmarks ----
+
+  /** Direct deserializer: byte[] → SerializationChunk without creating PBChunk/PBNode objects. */
+  @Benchmark
+  public SerializationChunk deserializeDirect() throws IOException {
+    return DirectProtoBufDeserializer.deserialize(serializedBytes, true);
+  }
+
+  /** Legacy path: byte[] → PBChunk → SerializationChunk. */
+  @Benchmark
+  public SerializationChunk deserializeViaPbChunk() throws IOException {
+    return pbSerialization.deserializeToChunkViaPbChunk(serializedBytes);
+  }
+
+  public static void main(String[] args) throws RunnerException {
+    Options opts =
+        new OptionsBuilder()
+            .include(ProtoBufBytesBenchmark.class.getSimpleName())
+            .addProfiler(GCProfiler.class)
+            .build();
+    new Runner(opts).run();
+  }
+}

--- a/core/src/performanceTest/java/io/lionweb/serialization/ProtoBufBytesBenchmark.java
+++ b/core/src/performanceTest/java/io/lionweb/serialization/ProtoBufBytesBenchmark.java
@@ -1,11 +1,7 @@
 package io.lionweb.serialization;
 
-import io.lionweb.LionWebVersion;
-import io.lionweb.model.Node;
 import io.lionweb.serialization.data.SerializationChunk;
 import java.io.*;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.openjdk.jmh.annotations.*;
@@ -60,14 +56,9 @@ public class ProtoBufBytesBenchmark {
       json = reader.lines().collect(Collectors.joining("\n"));
     }
 
-    JsonSerialization setupJs =
-        SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1);
-    List<Node> nodes = setupJs.deserializeToNodes(json);
-
+    // Use low-level deserialization to stay at SerializationChunk level (no language registration)
+    chunk = new LowLevelJsonSerialization().deserializeSerializationBlock(json);
     pbSerialization = SerializationProvider.getStandardProtoBufSerialization();
-
-    // Build the SerializationChunk once; both benchmarks reuse it
-    chunk = pbSerialization.serializeNodesToSerializationChunk(new ArrayList<>(nodes));
 
     // Pre-serialize so deserialization benchmarks measure only the parsing side
     serializedBytes = DirectProtoBufSerializer.serialize(chunk, true);

--- a/core/src/test/java/io/lionweb/serialization/DirectProtoBufTest.java
+++ b/core/src/test/java/io/lionweb/serialization/DirectProtoBufTest.java
@@ -1,0 +1,156 @@
+package io.lionweb.serialization;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.lionweb.model.Node;
+import io.lionweb.serialization.data.SerializationChunk;
+import io.lionweb.serialization.simplemath.IntLiteral;
+import io.lionweb.serialization.simplemath.SimpleMathLanguage;
+import io.lionweb.serialization.simplemath.Sum;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Validates that {@link DirectProtoBufSerializer} and {@link DirectProtoBufDeserializer} produce
+ * output that is byte-identical to the standard protobuf path and that round-trips are lossless.
+ */
+class DirectProtoBufTest {
+
+  // ---- Helpers ----
+
+  private ProtoBufSerialization standardSerialization() {
+    return SerializationProvider.getStandardProtoBufSerialization();
+  }
+
+  private void prepareForSimpleMath(ProtoBufSerialization s) {
+    s.getClassifierResolver().registerLanguage(SimpleMathLanguage.INSTANCE);
+    s.getInstantiator()
+        .registerCustomDeserializer(
+            SimpleMathLanguage.INT_LITERAL.getID(),
+            (concept, serializedNode, byId, props) ->
+                new IntLiteral(
+                    (Integer) props.get(concept.getPropertyByName("value")),
+                    serializedNode.getID()));
+    s.getInstantiator()
+        .registerCustomDeserializer(
+            SimpleMathLanguage.SUM.getID(),
+            (concept, serializedNode, byId, props) -> {
+              String leftId =
+                  serializedNode.getContainments().stream()
+                      .filter(c -> c.getMetaPointer().getKey().equals("SimpleMath_Sum_left"))
+                      .findFirst()
+                      .get()
+                      .getChildrenIds()
+                      .get(0);
+              String rightId =
+                  serializedNode.getContainments().stream()
+                      .filter(c -> c.getMetaPointer().getKey().equals("SimpleMath_Sum_right"))
+                      .findFirst()
+                      .get()
+                      .getChildrenIds()
+                      .get(0);
+              return new Sum(
+                  (IntLiteral) byId.get(leftId),
+                  (IntLiteral) byId.get(rightId),
+                  serializedNode.getID());
+            });
+  }
+
+  // ---- Byte-identity tests ----
+
+  @Test
+  void directSerializerProducesSameBytesAsLegacy() throws IOException {
+    Sum sum = new Sum(new IntLiteral(3), new IntLiteral(7));
+    ProtoBufSerialization s = standardSerialization();
+    // Build the same SerializationChunk and compare both serializers against it
+    SerializationChunk chunk = s.serializeTreesToSerializationChunk(List.of(sum));
+    byte[] legacy = s.serialize(chunk).toByteArray();
+    byte[] direct = DirectProtoBufSerializer.serialize(chunk, true);
+    assertArrayEquals(
+        legacy, direct, "Direct serializer must produce identical bytes to legacy path");
+  }
+
+  @Test
+  void directSerializerRoundTripSimpleMath() throws IOException {
+    Sum original = new Sum(new IntLiteral(1), new IntLiteral(2));
+    ProtoBufSerialization s = standardSerialization();
+    prepareForSimpleMath(s);
+
+    byte[] bytes = s.serializeTreesToByteArray(original);
+    List<Node> restored = s.deserializeToNodes(bytes);
+
+    assertEquals(1, restored.stream().filter(n -> n instanceof Sum).count());
+    Sum restoredSum = (Sum) restored.stream().filter(n -> n instanceof Sum).findFirst().get();
+    assertEquals(original, restoredSum);
+  }
+
+  @Test
+  void directDeserializerProducesSameChunkAsLegacy() throws IOException {
+    Sum sum = new Sum(new IntLiteral(5), new IntLiteral(6));
+    ProtoBufSerialization s = standardSerialization();
+
+    byte[] bytes = s.serializeNodesToByteArray(sum);
+
+    SerializationChunk viaDirect = DirectProtoBufDeserializer.deserialize(bytes, true);
+    SerializationChunk viaLegacy = s.deserializeToChunkViaPbChunk(bytes);
+
+    assertEquals(viaLegacy, viaDirect);
+  }
+
+  @Test
+  void largeLanguageRoundTrip() throws IOException {
+    InputStream is = getClass().getResourceAsStream("/serialization/LargeLanguage.json");
+    assertNotNull(is, "LargeLanguage.json must be on classpath");
+    String json;
+    try (java.io.BufferedReader r = new java.io.BufferedReader(new java.io.InputStreamReader(is))) {
+      json = r.lines().collect(Collectors.joining("\n"));
+    }
+
+    // Use low-level deserialization to get a SerializationChunk (no language registration needed)
+    SerializationChunk originalChunk =
+        new LowLevelJsonSerialization().deserializeSerializationBlock(json);
+
+    ProtoBufSerialization s = SerializationProvider.getStandardProtoBufSerialization();
+
+    // Direct serialize → direct deserialize
+    byte[] directBytes = DirectProtoBufSerializer.serialize(originalChunk, true);
+    SerializationChunk directChunk = DirectProtoBufDeserializer.deserialize(directBytes, true);
+
+    // Legacy serialize → legacy deserialize
+    SerializationChunk legacyChunk = s.deserializeToChunkViaPbChunk(directBytes);
+
+    assertEquals(
+        originalChunk,
+        directChunk,
+        "Large language: direct deserialized chunk must equal original");
+    assertEquals(
+        legacyChunk,
+        directChunk,
+        "Large language: direct deserialized chunk must equal legacy chunk");
+  }
+
+  @Test
+  void directSerializerMatchesLegacyForLargeLanguage() throws IOException {
+    InputStream is = getClass().getResourceAsStream("/serialization/LargeLanguage.json");
+    assertNotNull(is);
+    String json;
+    try (java.io.BufferedReader r = new java.io.BufferedReader(new java.io.InputStreamReader(is))) {
+      json = r.lines().collect(Collectors.joining("\n"));
+    }
+
+    // Use low-level deserialization to get a SerializationChunk (no language registration needed)
+    SerializationChunk chunk = new LowLevelJsonSerialization().deserializeSerializationBlock(json);
+
+    ProtoBufSerialization s = SerializationProvider.getStandardProtoBufSerialization();
+    byte[] legacy = s.serialize(chunk).toByteArray();
+    byte[] direct = DirectProtoBufSerializer.serialize(chunk, true);
+
+    assertArrayEquals(
+        legacy,
+        direct,
+        "Large language: direct serializer must produce identical bytes to legacy path");
+  }
+}

--- a/kotlin-core/src/main/kotlin/io/lionweb/kotlin/serialization/chunk/SerializedClassifierInstanceUtils.kt
+++ b/kotlin-core/src/main/kotlin/io/lionweb/kotlin/serialization/chunk/SerializedClassifierInstanceUtils.kt
@@ -82,6 +82,9 @@ fun SerializedClassifierInstance.subchunk(chunk: SerializationChunk): Serializat
         n.children.forEach {
             grow(chunk.classifierInstancesByID[it]!!)
         }
+        n.annotations.forEach {
+            grow(chunk.classifierInstancesByID[it]!!)
+        }
     }
     grow(this)
     val lwVersion = LionWebVersion.fromValue(chunk.serializationFormatVersion)

--- a/kotlin-core/src/test/kotlin/io/lionweb/kotlin/serialization/SerializedClassifierInstanceUtilsTest.kt
+++ b/kotlin-core/src/test/kotlin/io/lionweb/kotlin/serialization/SerializedClassifierInstanceUtilsTest.kt
@@ -1,14 +1,18 @@
 package io.lionweb.kotlin.serialization
 
+import io.lionweb.LionWebVersion
 import io.lionweb.kotlin.serialization.chunk.getProperty
+import io.lionweb.kotlin.serialization.chunk.subchunk
 import io.lionweb.lioncore.LionCore
 import io.lionweb.serialization.data.MetaPointer
+import io.lionweb.serialization.data.SerializationChunk
 import io.lionweb.serialization.data.SerializedClassifierInstance
 import io.lionweb.serialization.data.SerializedContainmentValue
 import io.lionweb.serialization.data.SerializedPropertyValue
 import java.util.Arrays
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class SerializedClassifierInstanceUtilsTest {
     @Test
@@ -77,5 +81,109 @@ class SerializedClassifierInstanceUtilsTest {
         assertEquals("1", sc1.getProperty(MetaPointer.get("LionCore-M3", "2024.1", "Language-version")))
         assertEquals("language-mylanguage-key", sc1.getProperty(MetaPointer.get("LionCore-M3", "2024.1", "IKeyed-key")))
         assertEquals("MyLanguage", sc1.getProperty(MetaPointer.get("LionCore-builtins", "2024.1", "LionCore-builtins-INamed-name")))
+    }
+
+    // --- subchunk tests ---
+
+    private val classifier = MetaPointer.get("lang", "1.0", "MyClass")
+    private val containment = MetaPointer.get("lang", "1.0", "children")
+
+    private fun node(id: String): SerializedClassifierInstance = SerializedClassifierInstance(id, classifier)
+
+    private fun chunkOf(vararg nodes: SerializedClassifierInstance): SerializationChunk =
+        SerializationChunk.fromNodes(LionWebVersion.v2024_1, nodes.toList())
+
+    @Test
+    fun subchunkOfLeafNodeContainsOnlyThatNode() {
+        val leaf = node("leaf")
+        val chunk = chunkOf(leaf)
+
+        val result = leaf.subchunk(chunk)
+
+        assertEquals(listOf("leaf"), result.classifierInstances.map { it.id })
+    }
+
+    @Test
+    fun subchunkPreservesSerializationFormatVersion() {
+        val root = node("root")
+        val chunk = chunkOf(root)
+
+        val result = root.subchunk(chunk)
+
+        assertEquals(LionWebVersion.v2024_1.versionString, result.serializationFormatVersion)
+    }
+
+    @Test
+    fun subchunkIncludesDirectChildren() {
+        val child = node("child")
+        val root = node("root").also { it.addChild(containment, "child") }
+        val chunk = chunkOf(root, child)
+
+        val result = root.subchunk(chunk)
+
+        val ids = result.classifierInstances.map { it.id }.toSet()
+        assertEquals(setOf("root", "child"), ids)
+    }
+
+    @Test
+    fun subchunkIncludesGrandchildren() {
+        val grandchild = node("grandchild")
+        val child = node("child").also { it.addChild(containment, "grandchild") }
+        val root = node("root").also { it.addChild(containment, "child") }
+        val chunk = chunkOf(root, child, grandchild)
+
+        val result = root.subchunk(chunk)
+
+        val ids = result.classifierInstances.map { it.id }.toSet()
+        assertEquals(setOf("root", "child", "grandchild"), ids)
+    }
+
+    @Test
+    fun subchunkIncludesAnnotations() {
+        val annotation = node("ann")
+        val root = node("root").also { it.addAnnotation("ann") }
+        val chunk = chunkOf(root, annotation)
+
+        val result = root.subchunk(chunk)
+
+        val ids = result.classifierInstances.map { it.id }.toSet()
+        assertEquals(setOf("root", "ann"), ids)
+    }
+
+    @Test
+    fun subchunkOfSubtreeExcludesUnrelatedSiblings() {
+        val sibling = node("sibling")
+        val child = node("child")
+        val root =
+            node("root").also {
+                it.addChild(containment, "child")
+                it.addChild(containment, "sibling")
+            }
+        val chunk = chunkOf(root, child, sibling)
+
+        val result = child.subchunk(chunk)
+
+        val ids = result.classifierInstances.map { it.id }.toSet()
+        assertEquals(setOf("child"), ids)
+        assertTrue("sibling" !in ids)
+        assertTrue("root" !in ids)
+    }
+
+    @Test
+    fun subchunkOfChildSubtreeIncludesOnlyItsDescendants() {
+        val grandchild = node("grandchild")
+        val child = node("child").also { it.addChild(containment, "grandchild") }
+        val sibling = node("sibling")
+        val root =
+            node("root").also {
+                it.addChild(containment, "child")
+                it.addChild(containment, "sibling")
+            }
+        val chunk = chunkOf(root, child, grandchild, sibling)
+
+        val result = child.subchunk(chunk)
+
+        val ids = result.classifierInstances.map { it.id }.toSet()
+        assertEquals(setOf("child", "grandchild"), ids)
     }
 }


### PR DESCRIPTION
We skip using the generated protobuffer code and go from bytes to PB classes to SerializationChunk and we got directly from bytes to SerializationChunk. 

Results in our benchmark:

## Serialization

| Metric | Direct | Legacy (via PBChunk) | Improvement |
|---|---:|---:|---:|
| Time | 4.68 ms/op | 7.79 ms/op | 1.66x faster |
| Allocation | 7.11 MB/op | 13.17 MB/op | 1.85x less |
| GC time | 73 ms total | 95 ms total | 1.30x less |

## Deserialization

| Metric | Direct | Legacy (via PBChunk) | Improvement |
|---|---:|---:|---:|
| Time | 5.55 ms/op | 8.29 ms/op | 1.49x faster |
| Allocation | 7.11 MB/op | 14.93 MB/op | 2.10x less |
| GC time | 59 ms total | 133 ms total | 2.25x less |

We also incidentally fix a minor issue with `subchunk`