### PR TITLE
Introduce InconsistentDataHandler for customizable inconsistent data handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### Version 1.3.15 (unreleased)
+
+* Introduce `InconsistentDataHandler` interface for customizable handling of inconsistent data during serialization/deserialization
+* Extend `InconsistentDataHandler` to handle missing classifiers, in addition to missing properties
+* Improve null and duplicate ID checks during deserialization
+
 ### Version 1.3.11
 
 * Fix foojay toolchain resolver plugin compatibility with Gradle 9 (update to 1.0.0)

--- a/core/src/main/java/io/lionweb/serialization/AbstractSerialization.java
+++ b/core/src/main/java/io/lionweb/serialization/AbstractSerialization.java
@@ -37,7 +37,7 @@ public abstract class AbstractSerialization {
   protected InconsistentDataHandler inconsistentDataHandler = THROWING_INCONSISTENT_DATA_HANDLER;
 
   /** Inconsistent data handler that throws an exception when inconsistent data is encountered. */
-  public static final InconsistentDataHandler THROWING_INCONSISTENT_DATA_HANDLER =
+  private static final InconsistentDataHandler THROWING_INCONSISTENT_DATA_HANDLER =
       new InconsistentDataHandler() {
 
         @Override

--- a/core/src/main/java/io/lionweb/serialization/AbstractSerialization.java
+++ b/core/src/main/java/io/lionweb/serialization/AbstractSerialization.java
@@ -34,7 +34,41 @@ public abstract class AbstractSerialization {
 
   protected LocalClassifierInstanceResolver instanceResolver;
 
-  /**
+  protected InconsistentDataHandler inconsistentDataHandler = THROWING_INCONSISTENT_DATA_HANDLER;
+
+  public static final InconsistentDataHandler THROWING_INCONSISTENT_DATA_HANDLER = new InconsistentDataHandler() {
+
+      @Override
+      public void handleMissingProperty(Classifier<?> classifier, MetaPointer metaPointer) {
+          throw new NullPointerException(
+              "Property with metaPointer "
+                  + metaPointer
+                  + " not found in classifier "
+                  + classifier
+                  + ". Properties: "
+                  + classifier.allProperties().stream()
+                  .map(MetaPointer::from)
+                  .collect(Collectors.toList()));
+      }
+  };
+
+    /**
+     * Sets the handler to deal with inconsistent data during the serialization or deserialization process.
+     * If the provided handler is null, a default throwing handler will be used.
+     *
+     * @param inconsistentDataHandler the {@code InconsistentDataHandler} implementation to handle
+     *                                inconsistent data; can be {@code null} to use the default handler.
+     */
+  public void setInconsistentDataHandler(@Nullable InconsistentDataHandler inconsistentDataHandler) {
+      if (inconsistentDataHandler == null) {
+          inconsistentDataHandler = THROWING_INCONSISTENT_DATA_HANDLER;
+      } else {
+          this.inconsistentDataHandler = inconsistentDataHandler;
+      }
+  }
+
+
+    /**
    * This guides what we do when deserializing a sub-tree and not being able to resolve the parent.
    */
   protected UnavailableNodePolicy unavailableParentPolicy = UnavailableNodePolicy.THROW_ERROR;
@@ -586,15 +620,9 @@ public abstract class AbstractSerialization {
                   deserializationStatus.getProperty(
                       classifier, serializedPropertyValue.getMetaPointer());
               if (property == null) {
-                throw new NullPointerException(
-                    "Property with metaPointer "
-                        + serializedPropertyValue.getMetaPointer()
-                        + " not found in classifier "
-                        + classifier
-                        + ". Properties: "
-                        + classifier.allProperties().stream()
-                            .map(MetaPointer::from)
-                            .collect(Collectors.toList()));
+                  inconsistentDataHandler.handleMissingProperty(
+                    classifier, serializedPropertyValue.getMetaPointer()
+                  );
               }
               Objects.requireNonNull(property.getType(), "property type should not be null");
               Object deserializedValue =

--- a/core/src/main/java/io/lionweb/serialization/AbstractSerialization.java
+++ b/core/src/main/java/io/lionweb/serialization/AbstractSerialization.java
@@ -36,10 +36,11 @@ public abstract class AbstractSerialization {
 
   protected InconsistentDataHandler inconsistentDataHandler = THROWING_INCONSISTENT_DATA_HANDLER;
 
-  public static final InconsistentDataHandler THROWING_INCONSISTENT_DATA_HANDLER = new InconsistentDataHandler() {
+  public static final InconsistentDataHandler THROWING_INCONSISTENT_DATA_HANDLER =
+      new InconsistentDataHandler() {
 
-      @Override
-      public void handleMissingProperty(Classifier<?> classifier, MetaPointer metaPointer) {
+        @Override
+        public void handleMissingProperty(Classifier<?> classifier, MetaPointer metaPointer) {
           throw new NullPointerException(
               "Property with metaPointer "
                   + metaPointer
@@ -47,28 +48,28 @@ public abstract class AbstractSerialization {
                   + classifier
                   + ". Properties: "
                   + classifier.allProperties().stream()
-                  .map(MetaPointer::from)
-                  .collect(Collectors.toList()));
-      }
-  };
+                      .map(MetaPointer::from)
+                      .collect(Collectors.toList()));
+        }
+      };
 
-    /**
-     * Sets the handler to deal with inconsistent data during the serialization or deserialization process.
-     * If the provided handler is null, a default throwing handler will be used.
-     *
-     * @param inconsistentDataHandler the {@code InconsistentDataHandler} implementation to handle
-     *                                inconsistent data; can be {@code null} to use the default handler.
-     */
-  public void setInconsistentDataHandler(@Nullable InconsistentDataHandler inconsistentDataHandler) {
-      if (inconsistentDataHandler == null) {
-          inconsistentDataHandler = THROWING_INCONSISTENT_DATA_HANDLER;
-      } else {
-          this.inconsistentDataHandler = inconsistentDataHandler;
-      }
+  /**
+   * Sets the handler to deal with inconsistent data during the serialization or deserialization
+   * process. If the provided handler is null, a default throwing handler will be used.
+   *
+   * @param inconsistentDataHandler the {@code InconsistentDataHandler} implementation to handle
+   *     inconsistent data; can be {@code null} to use the default handler.
+   */
+  public void setInconsistentDataHandler(
+      @Nullable InconsistentDataHandler inconsistentDataHandler) {
+    if (inconsistentDataHandler == null) {
+      inconsistentDataHandler = THROWING_INCONSISTENT_DATA_HANDLER;
+    } else {
+      this.inconsistentDataHandler = inconsistentDataHandler;
+    }
   }
 
-
-    /**
+  /**
    * This guides what we do when deserializing a sub-tree and not being able to resolve the parent.
    */
   protected UnavailableNodePolicy unavailableParentPolicy = UnavailableNodePolicy.THROW_ERROR;
@@ -620,17 +621,17 @@ public abstract class AbstractSerialization {
                   deserializationStatus.getProperty(
                       classifier, serializedPropertyValue.getMetaPointer());
               if (property == null) {
-                  inconsistentDataHandler.handleMissingProperty(
-                    classifier, serializedPropertyValue.getMetaPointer()
-                  );
+                inconsistentDataHandler.handleMissingProperty(
+                    classifier, serializedPropertyValue.getMetaPointer());
+              } else {
+                Objects.requireNonNull(property.getType(), "property type should not be null");
+                Object deserializedValue =
+                    deserializationStatus.deserializePropertyValue(
+                        property.getType(),
+                        serializedPropertyValue.getValue(),
+                        property.isRequired());
+                propertiesValues.put(property, deserializedValue);
               }
-              Objects.requireNonNull(property.getType(), "property type should not be null");
-              Object deserializedValue =
-                  deserializationStatus.deserializePropertyValue(
-                      property.getType(),
-                      serializedPropertyValue.getValue(),
-                      property.isRequired());
-              propertiesValues.put(property, deserializedValue);
             });
     ClassifierInstance<?> classifierInstance =
         getInstantiator()

--- a/core/src/main/java/io/lionweb/serialization/AbstractSerialization.java
+++ b/core/src/main/java/io/lionweb/serialization/AbstractSerialization.java
@@ -36,6 +36,9 @@ public abstract class AbstractSerialization {
 
   protected InconsistentDataHandler inconsistentDataHandler = THROWING_INCONSISTENT_DATA_HANDLER;
 
+  /**
+   * Inconsistent data handler that throws an exception when inconsistent data is encountered.
+   */
   public static final InconsistentDataHandler THROWING_INCONSISTENT_DATA_HANDLER =
       new InconsistentDataHandler() {
 
@@ -51,6 +54,11 @@ public abstract class AbstractSerialization {
                       .map(MetaPointer::from)
                       .collect(Collectors.toList()));
         }
+
+          @Override
+          public void handleMissingClassifier(MetaPointer serializedClassifier, String id) {
+              throw new RuntimeException("No metaPointer available for " + serializedClassifier + " for node " + id);
+          }
       };
 
   /**
@@ -63,7 +71,7 @@ public abstract class AbstractSerialization {
   public void setInconsistentDataHandler(
       @Nullable InconsistentDataHandler inconsistentDataHandler) {
     if (inconsistentDataHandler == null) {
-      inconsistentDataHandler = THROWING_INCONSISTENT_DATA_HANDLER;
+      this.inconsistentDataHandler = THROWING_INCONSISTENT_DATA_HANDLER;
     } else {
       this.inconsistentDataHandler = inconsistentDataHandler;
     }
@@ -538,11 +546,13 @@ public abstract class AbstractSerialization {
         n -> {
           ClassifierInstance<?> instantiated =
               instantiateFromSerialized(lionWebVersion, deserializationStatus, n, deserializedByID);
-          ClassifierInstance<?> prev = deserializedByID.put(n.getID(), instantiated);
-          if (n.getID() != null && prev != null) {
-            throw new IllegalStateException("Duplicate ID found: " + n.getID());
+          if (instantiated != null) {
+              ClassifierInstance<?> prev = deserializedByID.put(n.getID(), instantiated);
+              if (n.getID() != null && prev != null) {
+                  throw new IllegalStateException("Duplicate ID found: " + n.getID());
+              }
+              serializedToInstanceMap.put(n, instantiated);
           }
-          serializedToInstanceMap.put(n, instantiated);
         });
     if (sortedSerializedClassifierInstances.size() != serializedToInstanceMap.size()) {
       throw new IllegalStateException(
@@ -598,7 +608,7 @@ public abstract class AbstractSerialization {
     return nodesWithOriginalSorting;
   }
 
-  private ClassifierInstance<?> instantiateFromSerialized(
+  private @Nullable ClassifierInstance<?> instantiateFromSerialized(
       @Nonnull LionWebVersion lionWebVersion,
       DeserializationStatus deserializationStatus,
       SerializedClassifierInstance serializedClassifierInstance,
@@ -606,7 +616,8 @@ public abstract class AbstractSerialization {
     Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
     MetaPointer serializedClassifier = serializedClassifierInstance.getClassifier();
     if (serializedClassifier == null) {
-      throw new RuntimeException("No metaPointer available for " + serializedClassifierInstance);
+        inconsistentDataHandler.handleMissingClassifier(serializedClassifier, serializedClassifierInstance.getID());
+        return null;
     }
     Classifier<?> classifier = getClassifierResolver().resolveClassifier(serializedClassifier);
 

--- a/core/src/main/java/io/lionweb/serialization/AbstractSerialization.java
+++ b/core/src/main/java/io/lionweb/serialization/AbstractSerialization.java
@@ -36,9 +36,7 @@ public abstract class AbstractSerialization {
 
   protected InconsistentDataHandler inconsistentDataHandler = THROWING_INCONSISTENT_DATA_HANDLER;
 
-  /**
-   * Inconsistent data handler that throws an exception when inconsistent data is encountered.
-   */
+  /** Inconsistent data handler that throws an exception when inconsistent data is encountered. */
   public static final InconsistentDataHandler THROWING_INCONSISTENT_DATA_HANDLER =
       new InconsistentDataHandler() {
 
@@ -55,10 +53,11 @@ public abstract class AbstractSerialization {
                       .collect(Collectors.toList()));
         }
 
-          @Override
-          public void handleMissingClassifier(MetaPointer serializedClassifier, String id) {
-              throw new RuntimeException("No metaPointer available for " + serializedClassifier + " for node " + id);
-          }
+        @Override
+        public void handleMissingClassifier(MetaPointer serializedClassifier, String id) {
+          throw new RuntimeException(
+              "No metaPointer available for " + serializedClassifier + " for node " + id);
+        }
       };
 
   /**
@@ -547,11 +546,11 @@ public abstract class AbstractSerialization {
           ClassifierInstance<?> instantiated =
               instantiateFromSerialized(lionWebVersion, deserializationStatus, n, deserializedByID);
           if (instantiated != null) {
-              ClassifierInstance<?> prev = deserializedByID.put(n.getID(), instantiated);
-              if (n.getID() != null && prev != null) {
-                  throw new IllegalStateException("Duplicate ID found: " + n.getID());
-              }
-              serializedToInstanceMap.put(n, instantiated);
+            ClassifierInstance<?> prev = deserializedByID.put(n.getID(), instantiated);
+            if (n.getID() != null && prev != null) {
+              throw new IllegalStateException("Duplicate ID found: " + n.getID());
+            }
+            serializedToInstanceMap.put(n, instantiated);
           }
         });
     if (sortedSerializedClassifierInstances.size() != serializedToInstanceMap.size()) {
@@ -616,8 +615,9 @@ public abstract class AbstractSerialization {
     Objects.requireNonNull(lionWebVersion, "lionWebVersion should not be null");
     MetaPointer serializedClassifier = serializedClassifierInstance.getClassifier();
     if (serializedClassifier == null) {
-        inconsistentDataHandler.handleMissingClassifier(serializedClassifier, serializedClassifierInstance.getID());
-        return null;
+      inconsistentDataHandler.handleMissingClassifier(
+          serializedClassifier, serializedClassifierInstance.getID());
+      return null;
     }
     Classifier<?> classifier = getClassifierResolver().resolveClassifier(serializedClassifier);
 

--- a/core/src/main/java/io/lionweb/serialization/InconsistentDataHandler.java
+++ b/core/src/main/java/io/lionweb/serialization/InconsistentDataHandler.java
@@ -14,4 +14,13 @@ public interface InconsistentDataHandler {
    *     property.
    */
   void handleMissingProperty(Classifier<?> classifier, MetaPointer metaPointer);
+
+    /**
+     * Handles scenarios where a required classifier is missing during serialization or deserialization.
+     *
+     * @param serializedClassifier The {@code MetaPointer} representing the metadata or structure
+     *                              of the missing classifier.
+     * @param id                   A unique identifier associated with the classifier being processed.
+     */
+    void handleMissingClassifier(MetaPointer serializedClassifier, String id);
 }

--- a/core/src/main/java/io/lionweb/serialization/InconsistentDataHandler.java
+++ b/core/src/main/java/io/lionweb/serialization/InconsistentDataHandler.java
@@ -3,6 +3,15 @@ package io.lionweb.serialization;
 import io.lionweb.language.Classifier;
 import io.lionweb.serialization.data.MetaPointer;
 
+/** Interface for handling inconsistent data during serialization and deserialization. */
 public interface InconsistentDataHandler {
-    void handleMissingProperty(Classifier<?> classifier, MetaPointer metaPointer);
+  /**
+   * Handles operations when a required property is missing during data processing.
+   *
+   * @param classifier The {@link Classifier} instance that provides classification logic for the
+   *     data.
+   * @param metaPointer The {@code MetaPointer} referencing the metadata or structure of the missing
+   *     property.
+   */
+  void handleMissingProperty(Classifier<?> classifier, MetaPointer metaPointer);
 }

--- a/core/src/main/java/io/lionweb/serialization/InconsistentDataHandler.java
+++ b/core/src/main/java/io/lionweb/serialization/InconsistentDataHandler.java
@@ -1,0 +1,8 @@
+package io.lionweb.serialization;
+
+import io.lionweb.language.Classifier;
+import io.lionweb.serialization.data.MetaPointer;
+
+public interface InconsistentDataHandler {
+    void handleMissingProperty(Classifier<?> classifier, MetaPointer metaPointer);
+}

--- a/core/src/main/java/io/lionweb/serialization/InconsistentDataHandler.java
+++ b/core/src/main/java/io/lionweb/serialization/InconsistentDataHandler.java
@@ -15,12 +15,13 @@ public interface InconsistentDataHandler {
    */
   void handleMissingProperty(Classifier<?> classifier, MetaPointer metaPointer);
 
-    /**
-     * Handles scenarios where a required classifier is missing during serialization or deserialization.
-     *
-     * @param serializedClassifier The {@code MetaPointer} representing the metadata or structure
-     *                              of the missing classifier.
-     * @param id                   A unique identifier associated with the classifier being processed.
-     */
-    void handleMissingClassifier(MetaPointer serializedClassifier, String id);
+  /**
+   * Handles scenarios where a required classifier is missing during serialization or
+   * deserialization.
+   *
+   * @param serializedClassifier The {@code MetaPointer} representing the metadata or structure of
+   *     the missing classifier.
+   * @param id A unique identifier associated with the classifier being processed.
+   */
+  void handleMissingClassifier(MetaPointer serializedClassifier, String id);
 }

--- a/core/src/test/java/io/lionweb/serialization/JsonSerializationTest.java
+++ b/core/src/test/java/io/lionweb/serialization/JsonSerializationTest.java
@@ -22,6 +22,7 @@ import io.lionweb.serialization.simplemath.Sum;
 import io.lionweb.utils.LanguageValidator;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -1079,5 +1080,96 @@ public class JsonSerializationTest extends SerializationTest {
     jsonSerialization.registerLanguage(l1);
     Language l2unserialized = jsonSerialization.loadLanguage(serializedL2);
     assertInstancesAreEquals(l2, l2unserialized);
+  }
+
+  @Test
+  public void inconsistentDataHandlerCapturesMissingProperty() {
+    // Serialize a node, then manually inject an unknown property into the JSON
+    IntLiteral il = new IntLiteral(42, "il1");
+    JsonSerialization js = SerializationProvider.getStandardJsonSerialization();
+    JsonElement serialized = js.serializeTreesToJsonElement(il);
+
+    // Inject an unknown property into the serialized node
+    JsonObject chunk = serialized.getAsJsonObject();
+    JsonArray nodes = chunk.get("nodes").getAsJsonArray();
+    JsonObject node = nodes.get(0).getAsJsonObject();
+    JsonArray properties = node.get("properties").getAsJsonArray();
+    JsonObject unknownProp = new JsonObject();
+    JsonObject metaPointer = new JsonObject();
+    metaPointer.addProperty("language", "SimpleMath");
+    metaPointer.addProperty("version", "1");
+    metaPointer.addProperty("key", "SimpleMath_IntLiteral_unknownProp");
+    unknownProp.add("property", metaPointer);
+    unknownProp.addProperty("value", "someValue");
+    properties.add(unknownProp);
+
+    // Set up a capturing InconsistentDataHandler
+    List<String> capturedMissingProperties = new ArrayList<>();
+    InconsistentDataHandler capturingHandler =
+        new InconsistentDataHandler() {
+          @Override
+          public void handleMissingProperty(
+              Classifier<?> classifier, MetaPointer missingMetaPointer) {
+            capturedMissingProperties.add(missingMetaPointer.getKey());
+          }
+
+          @Override
+          public void handleMissingClassifier(MetaPointer serializedClassifier, String id) {
+            throw new RuntimeException("Unexpected missing classifier for id: " + id);
+          }
+        };
+
+    prepareDeserializationOfSimpleMath(js);
+    js.setInconsistentDataHandler(capturingHandler);
+    js.deserializeToNodes(serialized);
+
+    assertEquals(1, capturedMissingProperties.size());
+    assertEquals("SimpleMath_IntLiteral_unknownProp", capturedMissingProperties.get(0));
+  }
+
+  @Test
+  public void inconsistentDataHandlerCapturesMissingClassifier() {
+    // Build a raw JSON chunk with a node whose classifier is null (missing)
+    String json =
+        "{"
+            + "\"serializationFormatVersion\": \"2023.1\","
+            + "\"languages\": [],"
+            + "\"nodes\": ["
+            + "  {"
+            + "    \"id\": \"node1\","
+            + "    \"classifier\": null,"
+            + "    \"properties\": [],"
+            + "    \"containments\": [],"
+            + "    \"references\": [],"
+            + "    \"annotations\": [],"
+            + "    \"parent\": null"
+            + "  }"
+            + "]"
+            + "}";
+
+    List<String> capturedMissingClassifierIds = new ArrayList<>();
+    InconsistentDataHandler capturingHandler =
+        new InconsistentDataHandler() {
+          @Override
+          public void handleMissingProperty(
+              Classifier<?> classifier, MetaPointer missingMetaPointer) {
+            throw new RuntimeException("Unexpected missing property");
+          }
+
+          @Override
+          public void handleMissingClassifier(MetaPointer serializedClassifier, String id) {
+            capturedMissingClassifierIds.add(id);
+          }
+        };
+
+    JsonSerialization js =
+        SerializationProvider.getStandardJsonSerialization(LionWebVersion.v2023_1);
+    js.setInconsistentDataHandler(capturingHandler);
+    // The handler is invoked before the size-consistency check, so the exception is thrown
+    // after our handler has captured the inconsistency.
+    assertThrows(IllegalStateException.class, () -> js.deserializeToNodes(json));
+
+    assertEquals(1, capturedMissingClassifierIds.size());
+    assertEquals("node1", capturedMissingClassifierIds.get(0));
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=1.3.14
+version=1.3.15-SNAPSHOT
 specsVersion=2024.1
 jvmVersion=1.8
 org.gradle.jvmargs=-Dfile.encoding=UTF-8


### PR DESCRIPTION
Introduce `InconsistentDataHandler` interface to allow customizable handling of inconsistent data (missing properties, missing classifiers) during serialization and deserialization

Note: references and containments are handled by instantiator, so they are not covered here