### PR TITLE
Backfill CHANGELOG entries for versions 1.3.12–1.3.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+### Version 1.3.14
+
+* Enable dynamic nodes in JSON serialization to support annotations
+* Add `DirectProtoBufSerializer` and `DirectProtoBufDeserializer` for efficient binary serialization/deserialization
+* Optimize `DirectProtoBufSerializer` with single-pass indexing and cached indexing for improved performance
+* Introduce flat serialization plan in ProtoBuf serialization for improved cache locality and memory efficiency
+* Extend subchunk logic to include annotations
+* Extract ProtoBuf field numbers into a dedicated constants class for improved readability
+
+### Version 1.3.13
+
+* Refactor `Classifier`: replace stream-based feature lookups with enhanced for-loops for improved performance
+
+### Version 1.3.12
+
+* Optimize equality checks for `ClassifierInstances` and `ReferenceValues`
+* Optimize `addAnnotation` method for improved readability and performance
+* Bump org.jetbrains.dokka to 2.2.0
+
 ### Version 1.3.11
 
 * Fix foojay toolchain resolver plugin compatibility with Gradle 9 (update to 1.0.0)


### PR DESCRIPTION
## Summary

Adds missing CHANGELOG entries for three already-released versions that were not documented at release time:

* **1.3.14** — dynamic nodes for annotations, DirectProtoBuf serializer/deserializer, flat serialization plan, subchunk annotations, ProtoBuf field number constants
* **1.3.13** — `Classifier` stream-based lookup refactor
* **1.3.12** — equality check optimisations, `addAnnotation` improvement, dokka bump

No code changes — documentation only.