### PR TITLE
Sort protobuf intern tables by reference frequency for smaller varint indices

### DIFF
--- a/core/src/main/java/io/lionweb/serialization/DirectProtoBufSerializer.java
+++ b/core/src/main/java/io/lionweb/serialization/DirectProtoBufSerializer.java
@@ -12,11 +12,14 @@ import java.util.*;
 final class DirectProtoBufSerializer {
   // Strategy:
   //
-  // 1. Traverse all nodes once to populate string / language / meta-pointer intern tables and
-  //    build a plan containing every integer index and pre-computed body size.
-  // 2. Build cached tables (UTF-8 lengths, meta-pointer body sizes, language body sizes).
-  // 3. Compute the exact total byte count without touching domain objects.
-  // 4. Allocate one byte[] and write from the plan — zero HashMap lookups, zero domain traversal.
+  // 1. Traverse all nodes once to count reference frequencies for strings, languages, and
+  //    meta-pointers, then sort each intern table by descending frequency so the most-referenced
+  //    items get the smallest varint indices (index 1–127 encodes in 1 byte vs. 2+ bytes).
+  // 2. Traverse all nodes a second time to populate the pre-sorted intern tables and build a
+  //    flat plan containing every integer index and pre-computed body size.
+  // 3. Build cached tables (UTF-8 lengths, meta-pointer body sizes, language body sizes).
+  // 4. Compute the exact total byte count without touching domain objects.
+  // 5. Allocate one byte[] and write from the plan — zero HashMap lookups, zero domain traversal.
 
   private DirectProtoBufSerializer() {}
 
@@ -76,6 +79,35 @@ final class DirectProtoBufSerializer {
       metaPointers.add(mp);
       metaPointerIndex.put(mp, index);
       return index;
+    }
+  }
+
+  /** Frequency counters for strings, languages, and meta-pointers collected in a first pass. */
+  private static final class FreqState {
+    final HashMap<String, int[]> str = new HashMap<>();
+    final HashMap<LanguageVersion, int[]> lang = new HashMap<>();
+    final HashMap<MetaPointer, int[]> mp = new HashMap<>();
+
+    void countStr(String s) {
+      if (s != null) str.computeIfAbsent(s, k -> new int[1])[0]++;
+    }
+
+    void countMp(MetaPointer m) {
+      if (m == null) return;
+      boolean isNew = !mp.containsKey(m);
+      mp.computeIfAbsent(m, k -> new int[1])[0]++;
+      if (isNew) {
+        LanguageVersion lv = m.getLanguageVersion();
+        if (lv != null) {
+          boolean isNewLang = !lang.containsKey(lv);
+          lang.computeIfAbsent(lv, k -> new int[1])[0]++;
+          if (isNewLang) {
+            countStr(lv.getKey());
+            countStr(lv.getVersion());
+          }
+        }
+        countStr(m.getKey());
+      }
     }
   }
 
@@ -240,19 +272,39 @@ final class DirectProtoBufSerializer {
   static byte[] serialize(SerializationChunk chunk, boolean serializeEmptyFeatures) {
     List<SerializedClassifierInstance> instances = chunk.getClassifierInstances();
     int nodeCount = instances.size();
+    int estimatedStrings = Math.max(16, nodeCount * 4);
+    int estimatedMetaPointers = Math.max(16, nodeCount / 2);
 
-    // Heuristic pre-sizing to avoid resize overhead on typical models
+    SerializeState state =
+        buildSortedSerializeState(
+            instances,
+            chunk.getLanguages(),
+            serializeEmptyFeatures,
+            estimatedStrings,
+            8,
+            estimatedMetaPointers);
+    return serializeWithState(chunk, instances, serializeEmptyFeatures, state);
+  }
+
+  /** Serializes without frequency sorting — used by benchmarks to measure the unsorted baseline. */
+  static byte[] serializeUnsorted(SerializationChunk chunk, boolean serializeEmptyFeatures) {
+    List<SerializedClassifierInstance> instances = chunk.getClassifierInstances();
+    int nodeCount = instances.size();
     int estimatedStrings = Math.max(16, nodeCount * 4);
     int estimatedMetaPointers = Math.max(16, nodeCount / 2);
 
     SerializeState state = new SerializeState(estimatedStrings, 8, estimatedMetaPointers);
+    return serializeWithState(chunk, instances, serializeEmptyFeatures, state);
+  }
 
-    // Single traversal: populate intern tables AND build flat plan
+  private static byte[] serializeWithState(
+      SerializationChunk chunk,
+      List<SerializedClassifierInstance> instances,
+      boolean serializeEmptyFeatures,
+      SerializeState state) {
     SerializationPlan plan = buildSerializationPlan(state, instances, serializeEmptyFeatures);
-
     CachedTables cached = new CachedTables(state);
     int totalSize = computeChunkSize(chunk, cached, plan);
-
     byte[] result = new byte[totalSize];
     CodedOutputStream cos = CodedOutputStream.newInstance(result);
     try {
@@ -261,6 +313,79 @@ final class DirectProtoBufSerializer {
       throw new IllegalStateException("Unexpected IOException writing to byte array", e);
     }
     return result;
+  }
+
+  /**
+   * First pass: count how many times each string, language, and meta-pointer index will appear in
+   * the binary, then build a {@link SerializeState} with the intern tables pre-sorted by descending
+   * frequency. Items used most often get the smallest indices, which encode as shorter varints.
+   */
+  private static SerializeState buildSortedSerializeState(
+      List<SerializedClassifierInstance> instances,
+      List<LanguageVersion> declaredLanguages,
+      boolean serializeEmptyFeatures,
+      int estimatedStrings,
+      int estimatedLanguages,
+      int estimatedMetaPointers) {
+
+    FreqState freq = new FreqState();
+
+    for (SerializedClassifierInstance n : instances) {
+      freq.countStr(n.getID());
+      freq.countStr(n.getParentNodeID());
+      freq.countMp(n.getClassifier());
+
+      for (SerializedPropertyValue p : n.getProperties()) {
+        if (serializeEmptyFeatures || p.getValue() != null) {
+          freq.countStr(p.getValue());
+          freq.countMp(p.getMetaPointer());
+        }
+      }
+
+      for (SerializedContainmentValue c : n.getContainments()) {
+        if (serializeEmptyFeatures || !c.getChildrenIds().isEmpty()) {
+          for (String child : c.getChildrenIds()) freq.countStr(child);
+          freq.countMp(c.getMetaPointer());
+        }
+      }
+
+      for (SerializedReferenceValue r : n.getReferences()) {
+        if (serializeEmptyFeatures || !r.getValue().isEmpty()) {
+          for (SerializedReferenceValue.Entry e : r.getValue()) {
+            freq.countStr(e.getReference());
+            freq.countStr(e.getResolveInfo());
+          }
+          freq.countMp(r.getMetaPointer());
+        }
+      }
+
+      for (String ann : n.getAnnotations()) freq.countStr(ann);
+    }
+
+    SerializeState state =
+        new SerializeState(estimatedStrings, estimatedLanguages, estimatedMetaPointers);
+
+    // Seed strings sorted by descending frequency; tie-break alphabetically for determinism.
+    freq.str.entrySet().stream()
+        .sorted(
+            Comparator.<Map.Entry<String, int[]>>comparingInt(e -> -e.getValue()[0])
+                .thenComparing(Map.Entry.comparingByKey()))
+        .forEach(e -> state.stringIndexer(e.getKey()));
+
+    // Seed languages in the chunk's declared order so round-trips preserve language ordering.
+    // (Strings are already seeded above, so language key/version strings already have optimal
+    // indices when languageIndexer is called here.)
+    for (LanguageVersion lv : declaredLanguages) {
+      state.languageIndexer(lv);
+    }
+
+    // Seed meta-pointers sorted by descending frequency.
+    // Languages are already indexed, so metaPointerIndexer only looks them up, never reorders.
+    freq.mp.entrySet().stream()
+        .sorted(Comparator.comparingInt((Map.Entry<MetaPointer, int[]> e) -> -e.getValue()[0]))
+        .forEach(e -> state.metaPointerIndexer(e.getKey()));
+
+    return state;
   }
 
   private static SerializationPlan buildSerializationPlan(

--- a/core/src/performanceTest/java/io/lionweb/serialization/ProtoBufBytesBenchmark.java
+++ b/core/src/performanceTest/java/io/lionweb/serialization/ProtoBufBytesBenchmark.java
@@ -53,6 +53,11 @@ public class ProtoBufBytesBenchmark {
   }
 
   @Benchmark
+  public byte[] serializeDirectUnsorted() {
+    return DirectProtoBufSerializer.serializeUnsorted(chunk, true);
+  }
+
+  @Benchmark
   public SerializationChunk deserializeDirect() throws IOException {
     return DirectProtoBufDeserializer.deserialize(serializedBytes, true);
   }

--- a/core/src/test/java/io/lionweb/serialization/DirectProtoBufTest.java
+++ b/core/src/test/java/io/lionweb/serialization/DirectProtoBufTest.java
@@ -123,4 +123,76 @@ class DirectProtoBufTest {
 
     assertEquals(chunk, restored, "Large language: serialize → deserialize must be lossless");
   }
+
+  private SerializationChunk loadLargeLanguage() throws IOException {
+    InputStream is = getClass().getResourceAsStream("/serialization/LargeLanguage.json");
+    assertNotNull(is, "LargeLanguage.json must be on classpath");
+    String json;
+    try (java.io.BufferedReader r = new java.io.BufferedReader(new java.io.InputStreamReader(is))) {
+      json = r.lines().collect(Collectors.joining("\n"));
+    }
+    return new LowLevelJsonSerialization().deserializeSerializationBlock(json);
+  }
+
+  @Test
+  void frequencySortingProducesSmallerOrEqualOutput() throws IOException {
+    SerializationChunk chunk = loadLargeLanguage();
+
+    byte[] sorted = DirectProtoBufSerializer.serialize(chunk, true);
+    byte[] unsorted = DirectProtoBufSerializer.serializeUnsorted(chunk, true);
+
+    int savings = unsorted.length - sorted.length;
+    double pct = 100.0 * savings / unsorted.length;
+    System.out.printf(
+        "[size] unsorted=%d B  sorted=%d B  savings=%d B (%.2f%%)%n",
+        unsorted.length, sorted.length, savings, pct);
+
+    assertTrue(
+        sorted.length <= unsorted.length,
+        "Frequency-sorted output ("
+            + sorted.length
+            + " B) should be <= unsorted ("
+            + unsorted.length
+            + " B)");
+  }
+
+  @Test
+  void frequencySortingSerializationTimeOverhead() throws IOException {
+    SerializationChunk chunk = loadLargeLanguage();
+
+    int warmupRounds = 20;
+    int measureRounds = 100;
+
+    // Warmup
+    for (int i = 0; i < warmupRounds; i++) {
+      DirectProtoBufSerializer.serialize(chunk, true);
+      DirectProtoBufSerializer.serializeUnsorted(chunk, true);
+    }
+
+    // Measure unsorted
+    long t0 = System.nanoTime();
+    for (int i = 0; i < measureRounds; i++) {
+      DirectProtoBufSerializer.serializeUnsorted(chunk, true);
+    }
+    long unsortedNs = (System.nanoTime() - t0) / measureRounds;
+
+    // Measure sorted
+    t0 = System.nanoTime();
+    for (int i = 0; i < measureRounds; i++) {
+      DirectProtoBufSerializer.serialize(chunk, true);
+    }
+    long sortedNs = (System.nanoTime() - t0) / measureRounds;
+
+    double overhead = 100.0 * (sortedNs - unsortedNs) / unsortedNs;
+    System.out.printf(
+        "[perf] unsorted=%.2f ms  sorted=%.2f ms  overhead=%.1f%%%n",
+        unsortedNs / 1e6, sortedNs / 1e6, overhead);
+
+    // Sorted should not be more than 3× slower; the extra pass is lightweight.
+    assertTrue(
+        sortedNs < unsortedNs * 3,
+        String.format(
+            "Frequency sort overhead too large: unsorted=%.2f ms, sorted=%.2f ms",
+            unsortedNs / 1e6, sortedNs / 1e6));
+  }
 }


### PR DESCRIPTION
## Summary

- Adds a lightweight first pass over `SerializedClassifierInstance` nodes to count how many times each string and meta-pointer index will be written as a varint in the binary
- Pre-sorts the `interned_strings` and `interned_meta_pointers` tables by descending frequency so the most-referenced items get the smallest varint indices (indices 1–127 encode in 1 byte; 128–16383 in 2 bytes)
- Languages are kept in the chunk's declared order to preserve `SerializationChunk` round-trip equality
- Adds a package-private `serializeUnsorted` method and a matching JMH benchmark variant (`serializeDirectUnsorted`) as the before/after baseline

## Measured results (LargeLanguage.json, JUnit micro-benchmark)

| Metric | Value |
|---|---|
| Unsorted size | 1,363,302 B |
| Sorted size | 1,336,377 B |
| Byte savings | 26,925 B (**~2%**) |
| Serialization time overhead | ~130% (sorted takes ~2.3× longer due to the extra frequency-counting pass) |

For models with many nodes of the same classifier (e.g. large ASTs), the meta-pointer savings will be larger. For the LargeLanguage fixture the saving is modest because most strings (node IDs) are unique. For accurate speed numbers run the JMH benchmark: `./gradlew :core:performanceTest`.

## Test plan

- [x] All existing `core` tests pass (`./gradlew :core:test`)
- [x] New `frequencySortingProducesSmallerOrEqualOutput` test asserts sorted output ≤ unsorted bytes
- [x] New `frequencySortingSerializationTimeOverhead` test asserts sorted path is not more than 3× slower than unsorted
- [x] JMH benchmark has `serializeDirectUnsorted` for a proper before/after speed comparison

Closes #260